### PR TITLE
fix: remove unused test imports so `npm run build` (tsc) passes

### DIFF
--- a/src/__tests__/components/Step.test.tsx
+++ b/src/__tests__/components/Step.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { screen, within } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Step from '../../components/guide/Step';
 import { makeStep } from '../fixtures/guideData';
@@ -64,7 +64,6 @@ describe('Step', () => {
 
   it('step-content gets hidden-by-completion class when minimizeCompleted is active', async () => {
     localStorage.setItem('guideProgress:test', JSON.stringify({ '1-1': true }));
-    const user = userEvent.setup();
     const { container } = renderWithGuide(
       <Step step={makeStep('Minimizable')} stepId="1-1" stepNumber={1} />
     );

--- a/src/__tests__/integration/guideFilter.test.tsx
+++ b/src/__tests__/integration/guideFilter.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import GuideView from '../../components/guide/GuideView';
 import { mockGuideData, buildChapters } from '../fixtures/guideData';


### PR DESCRIPTION
The Pages deploy workflow runs `tsc && vite build`; tsc was failing on TS6133 unused-import errors in two test files, which aborted the build and prevented the gh-pages deploy from ever publishing. Remove the unused `within`, `user`, `vi`, and `fireEvent` bindings.