### PR TITLE
fix: sync deployed guide data from data/ at build time

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "node scripts/copy-data.mjs && vite",
+    "prebuild": "node scripts/copy-data.mjs",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "deploy": "npm run build && gh-pages -d dist",

--- a/public/data/guide_data.json
+++ b/public/data/guide_data.json
@@ -1,5 +1,5 @@
 {
-  "updatedOn": "2025-10-19",
+  "updatedOn": "2026-05-25",
   "title": "BRUHsailer Complete Guide",
   "chapters": [
     {
@@ -1661,7 +1661,22 @@
                   "level": 1,
                   "content": [
                     {
-                      "text": "60 woodcutting (higher is better, you will need 70 later and the rest will be trained with sulliusceps and 2t teaks outside Soul Wars). You can get this elsewhere too.\n",
+                      "text": "60 woodcutting (higher is better, you will need 70 later and the rest will be trained with sulliusceps and 2t teaks outside Soul Wars). You can get this elsewhere too. If you did not go all the way to 60 woodcutting, buy an adamant axe at Lunami",
+                      "formatting": {
+                        "color": {
+                          "r": 0,
+                          "g": 0,
+                          "b": 0
+                        },
+                        "fontSize": 12
+                      }
+                    },
+                    {
+                      "text": "’s Axe Shop in Auburnvale at your convenience later for speeding up the training.",
+                      "formatting": {}
+                    },
+                    {
+                      "text": "\n",
                       "formatting": {
                         "color": {
                           "r": 0,
@@ -1855,13 +1870,13 @@
                       "formatting": {}
                     },
                     {
-                      "text": "3 more oak logs for Sleeping Giants (do not cut these into shafts)",
+                      "text": "3 more oak logs for Sleeping Giants (do not cut these into shafts). ",
                       "formatting": {
                         "fontSize": 12
                       }
                     },
                     {
-                      "text": "\n",
+                      "text": "If possible, save around more 20 logs for future uses.\n",
                       "formatting": {}
                     }
                   ]
@@ -2476,7 +2491,7 @@
                   "formatting": {}
                 },
                 {
-                  "text": "to ",
+                  "text": "to level 36 thieving. ",
                   "formatting": {
                     "color": {
                       "r": 0,
@@ -2487,30 +2502,7 @@
                   }
                 },
                 {
-                  "text": "a bit over",
-                  "formatting": {
-                    "italic": true,
-                    "color": {
-                      "r": 0,
-                      "g": 0,
-                      "b": 0
-                    },
-                    "fontSize": 12
-                  }
-                },
-                {
-                  "text": " 42 thie",
-                  "formatting": {
-                    "color": {
-                      "r": 0,
-                      "g": 0,
-                      "b": 0
-                    },
-                    "fontSize": 12
-                  }
-                },
-                {
-                  "text": "ving (46,512 xp!). Bank one jangerb",
+                  "text": "Bank one jangerb",
                   "formatting": {
                     "fontSize": 12
                   }
@@ -2530,7 +2522,34 @@
                   "formatting": {}
                 },
                 {
-                  "text": "golovanova tops (you will need at least 2 tops). Run west and dig up a saltpetre for the diary.\n",
+                  "text": "golovanova tops (you will need at least 2 tops). Run west and dig up a saltpetre for the diary",
+                  "formatting": {
+                    "fontSize": 12
+                  }
+                },
+                {
+                  "text": ", then run to Land’s End and charter a ship to Aldarin. There thieve the upstairs chest in the western villa (",
+                  "formatting": {}
+                },
+                {
+                  "text": "Chest (Aldarin Villas) - OSRS Wiki",
+                  "formatting": {
+                    "underline": true,
+                    "color": {
+                      "r": 0.06666667,
+                      "g": 0.33333334,
+                      "b": 0.8
+                    },
+                    "url": "https://oldschool.runescape.wiki/w/Chest_(Aldarin_Villas)",
+                    "isLink": true
+                  }
+                },
+                {
+                  "text": ") to a bit over level 42 thieving (46,512 xp!).",
+                  "formatting": {}
+                },
+                {
+                  "text": "\n",
                   "formatting": {
                     "fontSize": 12
                   }
@@ -2751,7 +2770,7 @@
               "nestedContent": [],
               "metadata": {
                 "gp_stack": "20248 gp",
-                "items_needed": "7500 gp, bronze pickaxe, POH tab, ghostspeak amulet, ghost skull, two iron bars",
+                "items_needed": "7500 gp, bronze pickaxe, POH tab, two iron bars",
                 "skills_quests_met": "yes",
                 "total_time": "2d15h"
               }
@@ -3133,7 +3152,7 @@
                   }
                 },
                 {
-                  "text": " Charter a ship to Land’s end. B",
+                  "text": " Charter a ship Catherby (use the deposit box) or, if that shop is bought out, to Land’s end. B",
                   "formatting": {}
                 },
                 {
@@ -3156,7 +3175,7 @@
                   }
                 },
                 {
-                  "text": "h and 10 buckets of slime (if it is competitive or bought out, charter to Catherby and buy them there), 10/world at a time. ",
+                  "text": "h",
                   "formatting": {
                     "color": {
                       "r": 0,
@@ -3167,7 +3186,26 @@
                   }
                 },
                 {
-                  "text": "Charter a ship to Catherby. Buy steel arrowtips to round out 46 fletching (if you don’t have that level yet)",
+                  "text": ", 10/world at a time. Also at some point buy",
+                  "formatting": {}
+                },
+                {
+                  "text": " 10 buckets of slime (only 10 total). If y",
+                  "formatting": {
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0
+                    },
+                    "fontSize": 12
+                  }
+                },
+                {
+                  "text": "ou were at Land’s end, now charter",
+                  "formatting": {}
+                },
+                {
+                  "text": " a ship to Catherby. Buy steel arrowtips to round out 46 fletching (if you don’t have that level yet)",
                   "formatting": {}
                 },
                 {
@@ -3228,7 +3266,27 @@
                   "formatting": {}
                 },
                 {
-                  "text": "Grab insect repellant, collect two buckets of wax and five flax (diary) and speak with Sherlock (diary). Enter the ",
+                  "text": "Grab insect repellant, collect two buckets of wax and ",
+                  "formatting": {
+                    "fontSize": 12
+                  }
+                },
+                {
+                  "text": "ten",
+                  "formatting": {}
+                },
+                {
+                  "text": " flax (five ",
+                  "formatting": {
+                    "fontSize": 12
+                  }
+                },
+                {
+                  "text": "for the ",
+                  "formatting": {}
+                },
+                {
+                  "text": "diary, but we need ten) and speak with Sherlock (diary). Enter the ",
                   "formatting": {
                     "fontSize": 12
                   }
@@ -3248,7 +3306,17 @@
                   "formatting": {}
                 },
                 {
-                  "text": ". Continue Fishing Contest to the step where you get the trophy. Fly fish north of ",
+                  "text": ". Spin the flax into ",
+                  "formatting": {
+                    "fontSize": 12
+                  }
+                },
+                {
+                  "text": "ten linen yarn.",
+                  "formatting": {}
+                },
+                {
+                  "text": " Continue Fishing Contest to the step where you get the trophy. Fly fish north of ",
                   "formatting": {
                     "fontSize": 12
                   }
@@ -3608,7 +3676,7 @@
                   }
                 },
                 {
-                  "text": " ",
+                  "text": " Grab your sacks from the bank and use them to reduce the amount of running. ",
                   "formatting": {
                     "color": {
                       "r": 0,
@@ -3642,7 +3710,7 @@
                   }
                 },
                 {
-                  "text": "1 pineapple, 10 potatoes, 3 pots of flour, 4 cheese, 1 orange, 1 gnome spice and 120 produce items (all of onion, ",
+                  "text": "1 pineapple, 10 potatoes, 3 pots of flour, 4 cheese, 1 orange, 1 gnome spice and 120 produce items in any combination of the following (all of onion, ",
                   "formatting": {
                     "color": {
                       "r": 0,
@@ -4849,7 +4917,17 @@
             {
               "content": [
                 {
-                  "text": "Chronicle teleport to Varrock, buy a rune shortsword, green d’hide chaps, green d’hide vambraces from Scavvo in the Champions’ Guild",
+                  "text": "Chronicle teleport to Varrock, buy a rune sword (not a longsword",
+                  "formatting": {
+                    "fontSize": 12
+                  }
+                },
+                {
+                  "text": "!)",
+                  "formatting": {}
+                },
+                {
+                  "text": ", green d’hide chaps, green d’hide vambraces from Scavvo in the Champions’ Guild",
                   "formatting": {
                     "fontSize": 12
                   }
@@ -6178,7 +6256,7 @@
                   "level": 1,
                   "content": [
                     {
-                      "text": "You need to carry some waterskins for the mining, refilling them at Unkah as necessary. Previously there was a gravestone method, but currently it does not work.",
+                      "text": "You need to carry some waterskins for the mining, buying new ones at Unkah as necessary. Previously there was a gravestone method, but currently it does not work.",
                       "formatting": {}
                     },
                     {
@@ -6832,11 +6910,86 @@
                   }
                 },
                 {
-                  "text": "Make all your Golovanova fruit tops into botanical pies (cook them right away), prepare five more pie shells. ",
+                  "text": "Make all your Golovanova fruit tops into botanical pies (cook them right away), prepare five more pie shells. Start",
                   "formatting": {}
                 },
                 {
-                  "text": "Do The Lost Tribe up to the step where you need to visit Reldo, buy 10 bronze axes from Bob along the way. Cut and burn some oak logs for the diary. Finish Lost City (can convert all but one branch now), bring items to go down the Lumbridge swamp cave",
+                  "text": " The Lost ",
+                  "formatting": {
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0
+                    },
+                    "fontSize": 12
+                  }
+                },
+                {
+                  "text": "Tribe by speaking to Sigmunt.",
+                  "formatting": {}
+                },
+                {
+                  "text": " ",
+                  "formatting": {
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0
+                    },
+                    "fontSize": 12
+                  }
+                },
+                {
+                  "text": "S",
+                  "formatting": {}
+                },
+                {
+                  "text": "tart The Ides of Milk, speaking with people along the way for The Lost Tribe and ",
+                  "formatting": {
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0
+                    },
+                    "fontSize": 12
+                  }
+                },
+                {
+                  "text": "buying 10 bronze axes from Bob along the way.",
+                  "formatting": {}
+                },
+                {
+                  "text": " ",
+                  "formatting": {
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0
+                    },
+                    "fontSize": 12
+                  }
+                },
+                {
+                  "text": "Continue and complete The Ides of Milk, putting the lamp on prayer. Continue The Lost Tribe ",
+                  "formatting": {}
+                },
+                {
+                  "text": "up to the step where you need to visit Reldo",
+                  "formatting": {
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0
+                    },
+                    "fontSize": 12
+                  }
+                },
+                {
+                  "text": ".",
+                  "formatting": {}
+                },
+                {
+                  "text": " Cut and burn some oak logs for the diary. Finish Lost City (can convert all but one branch now), bring items to go down the Lumbridge swamp cave",
                   "formatting": {
                     "color": {
                       "r": 0,
@@ -6868,7 +7021,7 @@
             {
               "content": [
                 {
-                  "text": "Enter the Lumbridge Swamp, collect 5 swamp tar for quests. Enter the Lumbridge swamp caves and kill a big frog for the big frog leg and a cave bug for the diary step (do not go north with the candle as a light source, you will die).",
+                  "text": "Enter the Lumbridge Swamp, collect 25 swamp tar for quests. Enter the Lumbridge swamp caves and kill a big frog for the big frog leg and a cave bug for the diary step (do not go north with the candle as a light source, you will die).",
                   "formatting": {
                     "fontSize": 12
                   }
@@ -7075,7 +7228,7 @@
                   "formatting": {}
                 },
                 {
-                  "text": "), 4 oak logs, saw, hammer and an iron bar. Use a digsite pendant, speak with the Lead Navigator for Bone ",
+                  "text": "), 4 oak logs, hammer and an iron bar. Use a digsite pendant, speak with the Lead Navigator for Bone ",
                   "formatting": {
                     "color": {
                       "r": 0,
@@ -7131,7 +7284,7 @@
                   }
                 },
                 {
-                  "text": "Teleport to Varrock (chronicle), speak with the Apothecary for Bone Voyage and Romeo & Juliet and give him the Diary of Herbi Flax, show The Lost Tribe brooch to Reldo. Pay the estate agent to move your POH to Kourend. Grab a saw, hammer, 2 oak planks, 5 steel nails, 1 iron bar.",
+                  "text": "Teleport to Varrock (chronicle), speak with the Apothecary for Bone Voyage and Romeo & Juliet and give him the Diary of Herbi Flax, show The Lost Tribe brooch to Reldo. Pay the estate agent to move your POH to Kourend. Grab a hammer, 2 oak planks, 5 steel nails, 1 iron bar.",
                   "formatting": {}
                 },
                 {
@@ -7178,7 +7331,7 @@
               ],
               "metadata": {
                 "gp_stack": "445506 gp",
-                "items_needed": "10500 gp, Chronicle, barley seeds, 4 compost (from Step 21), rake, seed dibber, rune pickaxe, brooch, diary, digsite pendant, axe, tinderbox, 4 oak logs, saw, hammer, iron bar, Rag and Bone Man I bones, jugs of vinegar, marrentill potion(unf), 2 vodkas, cadava berries",
+                "items_needed": "10500 gp, Chronicle, barley seeds, 4 compost (from Step 21), rake, seed dibber, rune pickaxe, brooch, diary, digsite pendant, axe, tinderbox, 4 oak logs, hammer, iron bar, Rag and Bone Man I bones, jugs of vinegar, marrentill potion(unf), 2 vodkas, cadava berries",
                 "skills_quests_met": "yes",
                 "total_time": "5d19h"
               }
@@ -7192,7 +7345,7 @@
                   }
                 },
                 {
-                  "text": " the camp on Fossil Island (then rebank to get new items), unlock the mushtree system, mine 1,000 volcanic ash while in the area, set up your first bird run.",
+                  "text": " the camp on Fossil Island (then rebank to get new items), unlock the mushtree system including the teleport to the house on the hill by using a digsite pendant on the strange machine in said house, mine 1,000 volcanic ash while in the area, set up your first bird run.",
                   "formatting": {
                     "color": {
                       "r": 0,
@@ -7821,7 +7974,22 @@
                   "formatting": {}
                 },
                 {
-                  "text": "ALS (McGrubor’s Wood, diary step, run out and plant jute seeds for the diary, return to the fairy ring), BIS (Ardougne zoo, diary step), AIR (diary step), DIS (diary step), AJP",
+                  "text": "ALS (McGrubor’s Wood, diary step, run out and plant jute seeds for the diary, return to the fairy ring), BIS (Ardougne zoo, diary step), AIR (diary step), optional AIR to Auburnvale to purchase an addy axe (only if you do ",
+                  "formatting": {
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0
+                    },
+                    "fontSize": 12
+                  }
+                },
+                {
+                  "text": "not have 60 woodcutting yet), ",
+                  "formatting": {}
+                },
+                {
+                  "text": "DIS (diary step), AJP",
                   "formatting": {
                     "color": {
                       "r": 0,
@@ -8327,7 +8495,7 @@
                       }
                     },
                     {
-                      "text": "Continue the Garden of Death quest at Lake Molch Island and then Xeric’s Shrine. Kharedst’s memoirs teleport to the Graveyard of Heroes (Shayzien), run southwest and complete the Garden of Death at the Ruins of Morra. If you are not cut-eating all of your barbarian fishing, Kharedst’s memoirs teleport to Hosidius, r",
+                      "text": "Continue the Garden of Death quest at Lake Molch Island and then Xeric’s Shrine. Kharedst’s memoirs teleport to the Graveyard of Heroes (Shayzien), run southwest and complete the Garden of Death at the Ruins of Morra. If you are not cut-eating all of your barbarian fishing, Kharedst’s memoirs teleport to Hosidius, spin your ten linen yarn into five bolts of linen, then r",
                       "formatting": {}
                     },
                     {
@@ -10003,7 +10171,7 @@
               "nestedContent": [],
               "metadata": {
                 "gp_stack": "239158 gp",
-                "items_needed": "willow shortbow, mithril/steel arrows, bone crossbow, bone bolts, dramen staff,",
+                "items_needed": "bronze knives, iron knives, steel knives, ranged gear, lizardkickers, food, dramen staff,",
                 "skills_quests_met": "yes",
                 "total_time": "7d3h"
               }
@@ -10210,8 +10378,8 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "230380 gp (don’t bother wasting inv slots on GP at dragons)",
-                "items_needed": "rune pickaxe, dueling ring, 1 pure essence, air runes, earth staff, water staff, fire staff, law runes, bone crossbow, bone bolts, anti-dragon shield, salmon, amulet of accuracy (from Imp Catcher), coif/green d’hide chaps/vambraces",
+                "gp_stack": "238594 gp (don’t bother wasting inv slots on GP at dragons)",
+                "items_needed": "rune pickaxe, dueling ring, 1 pure essence, air runes, earth staff, water staff, chaos runes, mind runes, amulet of magic, fire staff, law runes, anti-dragon shield, salmon",
                 "skills_quests_met": "yes",
                 "total_time": "7d8h"
               }
@@ -10271,7 +10439,7 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "230880 gp",
+                "gp_stack": "239094 gp",
                 "items_needed": "magic secateurs, 3 papyrus, 1 ball of wool, 1 sack of 10 potatoes, 8 empty sacks, black candle (from Step 38), tinderbox, 10 silk, 10 logs, 12 willow branches",
                 "skills_quests_met": "yes",
                 "total_time": "7d11h"
@@ -10396,7 +10564,7 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "230880 gp",
+                "gp_stack": "239094 gp",
                 "items_needed": "Kharedst’s memoirs, lockpick,",
                 "skills_quests_met": "yes",
                 "total_time": "7d13h"
@@ -10550,7 +10718,7 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "235737 gp",
+                "gp_stack": "243951 gp",
                 "items_needed": "143 gp, games necklace, amulet of accuracy, fire staff, rune sword, fire staff, chaos runes (buy more?), gold bar, dragon bones, pickaxe, 2 ropes, guam leaf, vial of water, light source, tinderbox, pestle and mortar, 8 supercompost (note that ultra doesn’t work), spade, rake, seed dibber, plant cure (buy it in Trollheim), 3 Ugthanki dung, empty bucket, jangerberry",
                 "skills_quests_met": "yes",
                 "total_time": "7d15h"
@@ -11124,6 +11292,17 @@
                   "level": 1,
                   "content": [
                     {
+                      "text": "Once you hit level 76 farming it is recommended to plant an Attas anima seed and begin growing giant seaweed (not before then). It is best to teleport to house on the hill and zipline down. Even if you just finished a bird run, it is better to teleport than to run across the island.\n",
+                      "formatting": {
+                        "italic": true
+                      }
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
                       "text": "The best method to do Tithe farming at this level is ",
                       "formatting": {}
                     },
@@ -11179,7 +11358,7 @@
                       }
                     },
                     {
-                      "text": "20220622FarmingGuide",
+                      "text": "20260525FarmingGuide",
                       "url": "https://docs.google.com/document/d/1rAnKmezSQmnqFOCti4RWze-kvMoW8i4Kyk5xswJ-9Qc/edit#",
                       "isLink": true,
                       "formatting": {
@@ -11216,7 +11395,7 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "235737 gp",
+                "gp_stack": "243951 gp",
                 "items_needed": "seed dibber, spade, 15 watering cans, dramen staff, glassblowing pipe, molten glass, rune axe, ultracompost",
                 "skills_quests_met": "yes",
                 "total_time": "8d6h"
@@ -11284,7 +11463,7 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "233737 gp",
+                "gp_stack": "241951 gp",
                 "items_needed": "2000 gp, 1 hammer, 90 steel nails, 3 planks, 2 logs, 11 yew logs, 10 willow logs, staff of air, mind runes, law runes",
                 "skills_quests_met": "yes",
                 "total_time": "8d6h"
@@ -11560,7 +11739,7 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "227287 gp",
+                "gp_stack": "235501 gp",
                 "items_needed": "650 gp, dramen staff, butterfly net, several impling jars, rune pickaxe, swordfish, karambwans, knife, 20 limpwurt roots, candle (or FM cape/bruma torch), lockpick, air runes, law runes, fire runes, boots of lightness, many Shantay passes, 12 magic logs, 6 steel bars, 6 molten glass, 1 ashes, charcoal, 1 blood rune, 1 bones, 1 silver bar, garlic, pestle/mortar, spice, small fishing net, rope, sled, chocolate cake, spiked climbing boots, facemask, tinderbox, many lockpicks, prayer potions, fire staff, death runes (use blast spells except for Kamil)",
                 "skills_quests_met": "yes",
                 "total_time": "8d13h"
@@ -11589,7 +11768,7 @@
                   "level": 1,
                   "content": [
                     {
-                      "text": "Ring of dueling, complete Prince Ali Rescue and start Temple of the Eye (get the eye amulet, bank it) along the way, boat to Unkah (Tempoross)\n",
+                      "text": "Ring of dueling, complete Prince Ali Rescue and start Temple of the Eye to get the eye amulet (the quest item, not the similarly-named “Amulet of the eye” rare drop from Guardians of the Rift) and bank it. Take the boat to Unkah (Tempoross)\n",
                       "formatting": {}
                     }
                   ]
@@ -11761,7 +11940,7 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "227987 gp",
+                "gp_stack": "236201 gp",
                 "items_needed": "108 soft clay, 108 air runes, 216 law runes, fire staff",
                 "skills_quests_met": "yes",
                 "total_time": "8d14h"
@@ -11997,7 +12176,7 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "5987 gp",
+                "gp_stack": "14201 gp",
                 "items_needed": "Wind strikes, rune sword, food, 247500 gp (to buy 4400 cosmics), knife, 1590 unpowered orbs, many Wizard Mind Bombs, 33 Paddewwa tabs (66 if HCIM), 7 games necklaces (0 if HCIM), 5 rings of dueling, earth staff, 4770 cosmic runes",
                 "skills_quests_met": "yes",
                 "total_time": "8d17h"
@@ -12019,7 +12198,7 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "5837 gp",
+                "gp_stack": "14051 gp",
                 "items_needed": "150 gp, 2 empty vials, redberries, white berries, lantern lens (blow from molten glass), 5 earth runes, bucket",
                 "skills_quests_met": "yes",
                 "total_time": "8d18h"
@@ -12602,7 +12781,7 @@
               }
             },
             {
-              "text": "ssibly higher)",
+              "text": "ssibly higher)\n",
               "formatting": {
                 "color": {
                   "r": 0.023529412,
@@ -12610,16 +12789,20 @@
                   "b": 0.18039216
                 }
               }
-            },
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
             {
-              "text": "\n",
+              "text": "Sailing: 1\n",
               "formatting": {
                 "color": {
                   "r": 0.023529412,
                   "g": 0.6039216,
                   "b": 0.18039216
-                },
-                "fontSize": 12
+                }
               }
             }
           ],
@@ -12694,7 +12877,7 @@
               "formatting": {}
             },
             {
-              "text": "20251019Chapter1",
+              "text": "20260525Chapter1",
               "url": "https://docs.google.com/document/d/1gCez5XG5FA1kmmBYydur3RaI_cr-dYNJlnigRrByEX8/edit",
               "isLink": true,
               "formatting": {
@@ -12717,7 +12900,7 @@
               "formatting": {}
             },
             {
-              "text": "20251019Chapter2",
+              "text": "20260525Chapter2",
               "url": "https://docs.google.com/document/d/1YQiZ6curEYPpgm3DtjZcWHPoEEkGpYdXZ-I0gCM5p10/edit",
               "isLink": true,
               "formatting": {
@@ -12738,7 +12921,7 @@
               "formatting": {}
             },
             {
-              "text": "20251019Chapter3",
+              "text": "20260525Chapter3",
               "url": "https://docs.google.com/document/d/1O1VeAkwS6VAzGVy0GT205GqiNaOAbw17H5uyuMwz39o/edit?usp=sharing",
               "isLink": true,
               "formatting": {
@@ -12759,7 +12942,7 @@
               "formatting": {}
             },
             {
-              "text": "20251019DetailedStepsGuide",
+              "text": "20260525DetailedStepsGuide",
               "url": "https://docs.google.com/spreadsheets/d/1XZ-3Kja7_QS4Rxj4mJXeATXHBP03lrdUSt46gO3pWHk/edit#gid=1506136399",
               "isLink": true,
               "formatting": {
@@ -12790,6 +12973,136 @@
                 },
                 "url": "https://drive.google.com/drive/folders/1mqirlAU0Pk5OGI5V8NN9BhHKIeGwG1Ea",
                 "isLink": true
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
+                "fontFamily": "Arial"
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "Tool for comparing Landlubber to current: ",
+              "formatting": {
+                "fontFamily": "Arial"
+              }
+            },
+            {
+              "text": "https://pobblesbe.github.io/bruhsailer-transition-tool/",
+              "formatting": {
+                "underline": true,
+                "color": {
+                  "r": 0.06666667,
+                  "g": 0.33333334,
+                  "b": 0.8
+                },
+                "fontFamily": "Arial",
+                "url": "https://pobblesbe.github.io/bruhsailer-transition-tool/",
+                "isLink": true
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {}
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "\n",
+              "formatting": {}
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "Landlubber version (pre sailing):\n",
+              "formatting": {
+                "italic": true,
+                "fontFamily": "Arial"
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20251019Chapter1 - Landlubber",
+              "url": "https://docs.google.com/document/d/1xZ03yH6BFzXVS5Q17ghYB6oiITD6xgSDgHy_Ar5PakU/edit?usp=drive_link",
+              "isLink": true,
+              "formatting": {
+                "underline": true,
+                "fontFamily": "Arial"
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
+                "fontFamily": "Arial"
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20251019Chapter2 - Landlubber",
+              "url": "https://docs.google.com/document/d/1ppJIpSY88DJMIcn0BBUBODe7wOrQFrKmjeNv0OvKVMs/edit?usp=sharing",
+              "isLink": true,
+              "formatting": {
+                "underline": true,
+                "fontFamily": "Arial"
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
+                "fontFamily": "Arial"
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20251019Chapter3 - Landlubber",
+              "url": "https://docs.google.com/document/d/1yPlKxtX96f4eYsXaga57Hl4EW7M8WMscVKaSfDoGGaA/edit?usp=sharing",
+              "isLink": true,
+              "formatting": {
+                "underline": true,
+                "fontFamily": "Arial"
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
+                "fontFamily": "Arial"
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20251019DetailedStepsGuide - Landlubber",
+              "url": "https://docs.google.com/spreadsheets/d/1BspIE07aWfP0Z2o2y3L5Qi9P27ctinDA9igNOkIhK3o/edit?usp=sharing",
+              "isLink": true,
+              "formatting": {
+                "underline": true,
+                "fontFamily": "Arial"
               }
             },
             {
@@ -13056,7 +13369,125 @@
             {
               "text": "\n",
               "formatting": {
+                "italic": true,
+                "fontSize": 11,
+                "fontFamily": "Arial"
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20260308BRUHsailerChangelog.txt",
+              "formatting": {
+                "underline": true,
+                "color": {
+                  "r": 0.06666667,
+                  "g": 0.33333334,
+                  "b": 0.8
+                },
+                "fontFamily": "Arial",
+                "url": "https://drive.google.com/file/d/1sj648WdEj8dXS-kJm5xyKZFxa-APM5CX/view?usp=sharing",
+                "isLink": true
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
                 "fontSize": 13
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20260310: Moved Zogre Flesh Eaters for early inoculation station, finished Shrouded Ocean",
+              "formatting": {
+                "italic": true
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
+                "fontFamily": "Arial"
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20260327BRUHsailerChangelog.txt",
+              "formatting": {
+                "underline": true,
+                "color": {
+                  "r": 0.06666667,
+                  "g": 0.33333334,
+                  "b": 0.8
+                },
+                "fontFamily": "Arial",
+                "url": "https://drive.google.com/file/d/16LdgtZVcg81vRr2-RZ-0J9tQW8kJG-sh/view?usp=sharing",
+                "isLink": true
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
+                "italic": true
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20260410BRUHsailerChangelog.txt",
+              "formatting": {
+                "underline": true,
+                "color": {
+                  "r": 0.06666667,
+                  "g": 0.33333334,
+                  "b": 0.8
+                },
+                "url": "https://drive.google.com/file/d/1Vgsc6cbQkVZq0zK_1N8kiITWsTdirKJl/view?usp=sharing",
+                "isLink": true
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
+                "fontFamily": "Arial"
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20260525BRUHsailerChangelog.txt",
+              "formatting": {
+                "underline": true,
+                "color": {
+                  "r": 0.06666667,
+                  "g": 0.33333334,
+                  "b": 0.8
+                },
+                "fontFamily": "Arial",
+                "url": "https://drive.google.com/file/d/1heQH8NuLiDIc7S9MwRoW-Y7uoRlgm-5-/view?usp=sharing",
+                "isLink": true
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
+                "italic": true
               }
             }
           ],
@@ -13189,16 +13620,16 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "162k gp",
+                "gp_stack": "150k gp",
                 "items_needed": "cash stack, 100 earth orbs,",
-                "total_time": "9d10h",
+                "total_time": "8d19h",
                 "skills_quests_met": "yes"
               }
             },
             {
               "content": [
                 {
-                  "text": "Run artefacts in Piscarillius while attaching the staves to the orbs and alching them while running, using your Kharedst’s memoirs for transportation and dueling rings to Ferox Enclave to bank and/or restore run energy as needed. Repeat this process of buying staves in Yanille, attaching and alching orbs while running artefacts until all 1590 have been processed. Also buy 500 law runes and 500 soul runes (50 per world) in Yanille in between buying battlestaves. Grab coins, a rope, antipoison, barcrawl card, 15 oak logs, digsite teleport and run to the sawmill, make them into planks and buy 1 iron and 300 steel nails (if you have spares from Tempoross you can skip those items) as well as five bolts of cloth. Head to the Jolly Boar Inn, complete the barcrawl and speak with the third brother for Family Crest. Games’ necklace teleport to the barbarian outpost, show the barcrawl card to the Barbarian Guard to complete the barcrawl. Toggle vial smashing. Teleport to your POH and buy two bedrooms, then build a bed in each (Oak or Wooden is fine). Next buy a dining room and build a rope bell-pull. Teleport to Ardougne, pay the estate agent to swap your POH location to Rimmington, then hire the highest tier servant possible at the Servant’s Guild - Cook for levels 39 and below, Butler for levels 40 and up (you shouldn’t be level 50+ construction yet but if you are: good for you, and hire the Demon Butler).\n",
+                  "text": "Run artefacts in Piscarillius while attaching the staves to the orbs and alching them while running, using your Kharedst’s memoirs for transportation and dueling rings to Ferox Enclave to bank and/or restore run energy as needed. Repeat this process of buying staves in Yanille, attaching and alching orbs while running artefacts until all 1590 have been processed. Also buy 500 law runes and 500 soul runes (50 per world) in Yanille in between buying battlestaves. Grab coins, a rope, antipoison, barcrawl card, 15 oak logs, digsite teleport and run to the sawmill, make them into planks and buy 101 iron and 700 steel nails (if you have spares from Tempoross you can skip those items) as well as five bolts of cloth. Head to the Jolly Boar Inn, complete the barcrawl and speak with the third brother for Family Crest. Games’ necklace teleport to the barbarian outpost, show the barcrawl card to the Barbarian Guard to complete the barcrawl. Toggle vial smashing. Teleport to your POH and buy two bedrooms, then build a bed in each (Oak or Wooden is fine). Next buy a dining room and build a rope bell-pull. Teleport to Ardougne, pay the estate agent to swap your POH location to Rimmington, then hire the highest tier servant possible at the Servant’s Guild - Cook for levels 39 and below, Butler for levels 40 and up (you shouldn’t be level 50+ construction yet but if you are: good for you, and hire the Demon Butler).\n",
                   "formatting": {}
                 }
               ],
@@ -13221,10 +13652,10 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "3m gp",
+                "gp_stack": "3.0m gp",
                 "items_needed": "Kharedst’s memoirs, 300k gp (obtained during the step), rings of dueling, earth orbs, battlestaves (obtained during the step), rope, antipoison, barcrawl card, 15 oak logs, digsite pendant, games necklace",
                 "skills_quests_met": "yes",
-                "total_time": "9d17h"
+                "total_time": "9d2h"
               }
             },
             {
@@ -13298,6 +13729,15 @@
                   "level": 1,
                   "content": [
                     {
+                      "text": "Save 50 oak planks for future uses after you’re done.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
                       "text": "Optional but recommended: when in Ardougne, charter a ship to Aldarin and buy an adamant kiteshield from Shields of Mistrock for tank gear for Rex.",
                       "formatting": {
                         "italic": true
@@ -13311,16 +13751,16 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "2.66m gp",
+                "gp_stack": "2.65m gp",
                 "items_needed": "cash stack, knife, teak log, rune axe, saw, hammer, forestry kit",
                 "skills_quests_met": "yes",
-                "total_time": "9d17h"
+                "total_time": "9d12h"
               }
             },
             {
               "content": [
                 {
-                  "text": "If you have (at least) two grown teak trees on Fossil Island, use the butler method to chop and make 1100 teak planks (example video of 2 tick teaks with butler plankmake: ",
+                  "text": "If you have (at least) two grown teak trees on Fossil Island, use the butler method to chop and make 1175 teak planks (example video of 2 tick teaks with butler plankmake: ",
                   "formatting": {}
                 },
                 {
@@ -13417,10 +13857,10 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "2.05m gp",
+                "gp_stack": "2.0m gp",
                 "items_needed": "cash stack, knife, teak log, rune axe, saw, hammer",
                 "skills_quests_met": "yes",
-                "total_time": "9d20h"
+                "total_time": "9d15h"
               }
             },
             {
@@ -13432,10 +13872,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "2.01m gp",
+                "gp_stack": "2.0m gp",
                 "items_needed": "cash stack, Crandor map, rune sword, anti-dragon shield, swordfish, prayer potions (make at bank if you haven’t already), ring of recoil (optional), teak logs + knife (optional)",
                 "skills_quests_met": "yes",
-                "total_time": "9d21h"
+                "total_time": "9d6h"
               }
             },
             {
@@ -13454,7 +13894,7 @@
                 "gp_stack": "2.0m gp",
                 "items_needed": "pickaxe",
                 "skills_quests_met": "yes",
-                "total_time": "9d23h"
+                "total_time": "9d8h"
               }
             },
             {
@@ -13476,10 +13916,10 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "1.8m gp",
+                "gp_stack": "1.7m gp",
                 "items_needed": "200k gp, 2 ropes, yew longbow, 10 steel arrows, spade, food (swordfish?), rune sword, energy pots if you have them, wind strike/bolt runes, prayer potion",
                 "skills_quests_met": "yes",
-                "total_time": "10d1h"
+                "total_time": "9d10h"
               }
             },
             {
@@ -13491,10 +13931,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "1.7m gp",
+                "gp_stack": "1.6m gp",
                 "items_needed": "law rune, earth rune, air rune, coins",
                 "skills_quests_met": "yes",
-                "total_time": "10d1h"
+                "total_time": "9d10h"
               }
             },
             {
@@ -13525,16 +13965,16 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "1.7m gp",
+                "gp_stack": "1.6m gp",
                 "items_needed": "pickaxe, chronicle, ring of dueling, bracelets of clay, law runes, earth runes, air runes, crystal saw, 2 mahogany planks, gold leaf, coins",
                 "skills_quests_met": "yes",
-                "total_time": "10d1h"
+                "total_time": "9d10h"
               }
             },
             {
               "content": [
                 {
-                  "text": "Take a wind spell (staff + runes, wind bolt works great)",
+                  "text": "Take an earth spell (staff + runes, earth bolt works great)",
                   "formatting": {}
                 },
                 {
@@ -13645,10 +14085,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "1.7m gp",
-                "items_needed": "cash stack, chaos runes, air staff, law runes, trollweis, rune sword, rune pickaxe, Paddewwa tabled/water runes, law runes, swordfish, prayer potions",
+                "gp_stack": "1.6m gp",
+                "items_needed": "cash stack, chaos runes, earth staff, air runes, law runes, trollweis, rune sword, rune pickaxe, Paddewwa tabled/water runes, law runes, swordfish, prayer potions",
                 "skills_quests_met": "yes",
-                "total_time": "10d1h"
+                "total_time": "9d10h"
               }
             },
             {
@@ -13713,10 +14153,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "1.7m gp",
+                "gp_stack": "1.6m gp",
                 "items_needed": "chaos runes, air runes, water staff, law runes, swordfish, prayer potions, games necklace",
                 "skills_quests_met": "yes",
-                "total_time": "10d2h"
+                "total_time": "9d11h"
               }
             },
             {
@@ -13754,7 +14194,7 @@
                 "gp_stack": "1.6m gp",
                 "items_needed": "cash stack, air runes, water staff, law runes, 2k stardust, full initiate, 1 molten glass, 1 enchanted gem",
                 "skills_quests_met": "yes",
-                "total_time": "10d2h"
+                "total_time": "9d11h"
               }
             },
             {
@@ -13818,7 +14258,7 @@
                 "gp_stack": "1.6m gp",
                 "items_needed": "spade, lit candle, rope, bronze wire, chisel, rune sword, swordfish, prayer potions, energy potions, dramen staff, Crumble Undead runes, 4 rogue kits (optional), rune pickaxe, gout tuber",
                 "skills_quests_met": "yes",
-                "total_time": "10d3h"
+                "total_time": "9d12h"
               }
             },
             {
@@ -13839,7 +14279,7 @@
                 "gp_stack": "1.6m gp",
                 "items_needed": "1330 gp, ice gloves, blunt axe",
                 "skills_quests_met": "yes",
-                "total_time": "10d3h"
+                "total_time": "9d12h"
               }
             },
             {
@@ -13930,7 +14370,7 @@
                 "gp_stack": "1.6m gp",
                 "items_needed": "blamish snail slime, harralander, vial of water, fishing rod, lockpick, jade, necklace mould, silver bar, air runes, cosmic rune, swordfish/cake/wines, pure essence, empty sack",
                 "skills_quests_met": "yes",
-                "total_time": "10d4h"
+                "total_time": "9d13h"
               }
             },
             {
@@ -14019,7 +14459,7 @@
                 "gp_stack": "1.6m gp",
                 "items_needed": "both HAM robe sets, games necklace, lockpick, light source, rune sword, swordfish, tinderbox, mining helmet",
                 "skills_quests_met": "yes",
-                "total_time": "10d5h"
+                "total_time": "9d14h"
               }
             },
             {
@@ -14090,7 +14530,7 @@
                 "gp_stack": "1.6m gp",
                 "items_needed": "cash stack, bullseye lantern, lantern lens, cut sapphire, chisel, tinderbox, rune pickaxe, wind bolt spells (wind staff, chaos runes), molten glass, law runes, gold bar, swordfish, energy potions, prayer potions, dueling ring, dwarven lore",
                 "skills_quests_met": "yes",
-                "total_time": "10d5h"
+                "total_time": "9d14h"
               }
             },
             {
@@ -14170,7 +14610,7 @@
                   }
                 },
                 {
-                  "text": " at this south spot shown by Binxy, until you are 10k xp away from level 60 mining (you don’t have to buy any sand for this. Feel free to get the level instead, if you want). Buy the ancient staff from Eblis. Once done, head south (rebank at the Ruins of Unkah if needed),",
+                  "text": " at this south spot shown by Binxy, until you are 10k xp away from level 60 mining (you don’t have to buy any sand for this. Feel free to get the level instead, if you want). Mine and bank one piece of granite (any size) before leaving. Buy the ancient staff from Eblis. Once done, head south (rebank at the Ruins of Unkah if needed),",
                   "formatting": {}
                 },
                 {
@@ -14216,7 +14656,7 @@
                   "level": 1,
                   "content": [
                     {
-                      "text": "You need to carry some waterskins for the mining, refilling them at Unkah as necessary. Previously there was a gravestone method, but currently it does not work.\n",
+                      "text": "You need to carry some waterskins for the mining, buying new ones at Unkah as necessary. Previously there was a gravestone method, but currently it does not work.\n",
                       "formatting": {}
                     }
                   ]
@@ -14327,7 +14767,7 @@
                 "gp_stack": "1.5m gp",
                 "items_needed": "cash stack, gold bar, ammo mould, rune sword, swordfish, waterskins, rune pickaxe, chisel, bread/cake, tinderbox, candle, regular log, oak log, willow log, maple log, soft clay, coal, Crumble Undead runes, air staff, fire runes, chaos runes, energy potions, bucket of water, celestial ring, varrock body 2, Efaritay’s aid",
                 "skills_quests_met": "yes",
-                "total_time": "10d9h"
+                "total_time": "9d18h"
               }
             },
             {
@@ -14437,10 +14877,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "1.5m gp",
+                "gp_stack": "1.4m gp",
                 "items_needed": "cash stack, rune sword, swordfish, waterskins, yew logs, grimy harralander, vial of water, pestle+mortar, necklace of passage, small fishing net, rope, law runes, air staff, light source, knife, rune pickaxe, yew longbow, steel arrows, regular needle, 2 thread, desert clothing, prayer potions",
                 "skills_quests_met": "yes",
-                "total_time": "10d10h"
+                "total_time": "9d19h"
               }
             },
             {
@@ -14520,10 +14960,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "1.5m gp",
-                "items_needed": "cash stack, kitten/cat, light source, tinderbox, bag of salt, willow log, bucket of sap, waterskins, energy potions, prayer potions, rune sword, swordfish, games necklace, antipoison, digsite pendant, barcrawl card, 10 oak logs, digsite teleport, 3500 gp.",
+                "gp_stack": "1.4m gp",
+                "items_needed": "cash stack, kitten/cat, light source, tinderbox, bag of salt, willow log, bucket of sap, waterskins, energy potions, prayer potions, rune sword, swordfish, games necklace, antipoison, digsite pendant, 10 oak logs, digsite teleport, 3500 gp.",
                 "skills_quests_met": "yes",
-                "total_time": "10d11h"
+                "total_time": "9d20h"
               }
             },
             {
@@ -14647,7 +15087,7 @@
                       "formatting": {}
                     },
                     {
-                      "text": "20220622FarmingGuide",
+                      "text": "20260327FarmingGuide",
                       "url": "https://docs.google.com/document/d/1rAnKmezSQmnqFOCti4RWze-kvMoW8i4Kyk5xswJ-9Qc/edit?usp=sharing",
                       "isLink": true,
                       "formatting": {
@@ -14666,7 +15106,7 @@
                 "gp_stack": "1.5m gp",
                 "items_needed": "kitten/cat, full initiate, catspeak amulet, 5 death runes, oily fishing rod, fishing bait, ice gloves, scorpion cage, rune sword, anti-dragon shield, swordfish, energy potions, prayer potions, Commorb, Kharedst’s memoirs, dramen staff, necklace of passage, damaged soulbearer",
                 "skills_quests_met": "yes",
-                "total_time": "10d12h"
+                "total_time": "9d21h"
               }
             },
             {
@@ -14706,16 +15146,14 @@
                 {
                   "text": "\n",
                   "formatting": {}
-                },
-                {
-                  "text": "Total time:"
                 }
               ],
               "nestedContent": [],
               "metadata": {
                 "gp_stack": "1.5m gp",
                 "items_needed": "cat, catspeak amulet, rune axe, tinderbox, rune sword",
-                "skills_quests_met": "yes"
+                "skills_quests_met": "yes",
+                "total_time": "9d21h"
               }
             },
             {
@@ -14763,7 +15201,7 @@
                 "gp_stack": "1.5m gp",
                 "items_needed": "16 steel bars, hammer, Commorb, 20 pure essence, catspeak amulet, cat",
                 "skills_quests_met": "yes",
-                "total_time": "10d13h"
+                "total_time": "9d22h"
               }
             },
             {
@@ -14810,7 +15248,7 @@
                 "gp_stack": "1.5m gp",
                 "items_needed": "cash stack, law runes, soul runes, earth runes, water runes, chronicle, commorb, Dorgesh-Kaan spheres, green dhide leather, rune sword, earmuffs, light source",
                 "skills_quests_met": "yes",
-                "total_time": "10d14h"
+                "total_time": "9d23h"
               }
             },
             {
@@ -14889,7 +15327,7 @@
                 "gp_stack": "1.5m gp",
                 "items_needed": "law runes, soul runes, earth staff, ghostspeak amulet, 8 empty pots, 8 buckets of slime, 8 bones, silver bar, ice coolers, dramen staff, plank sack",
                 "skills_quests_met": "yes",
-                "total_time": "10d15h"
+                "total_time": "10d0h"
               }
             },
             {
@@ -15010,7 +15448,7 @@
                 "gp_stack": "1.5m gp",
                 "items_needed": "cash stack, all steel items from Step 20 and steel platelegs from Step 15, 263 steel nails, druid pouch, hammer, 17 planks, ring of charos(a), blessed silver sickle, rune sword, wolfsbane, swordfish, prayer potions, law runes, soul runes, bucket, spade, rune pickaxe, swamp paste, 10 bronze axes, 4 tinderboxes, 2 steel bars, coal, 15 salmon, dramen staff, garlic, silver dust, harralander, red spider eggs, vial of water, small fishing net, rope",
                 "skills_quests_met": "yes",
-                "total_time": "10d16h"
+                "total_time": "10d1h"
               }
             },
             {
@@ -15042,7 +15480,7 @@
                 "gp_stack": "1.5m gp",
                 "items_needed": "cash stack, law runes, soul runes, earth staff, 3 of each red/blue/yellow dye, ghostspeak amulet, Ecto-tokens, nettle tea, bucket of milk, silk, needle, thread, knife, spade, swordfish, rune sword",
                 "skills_quests_met": "yes",
-                "total_time": "10d16h"
+                "total_time": "10d1h"
               }
             },
             {
@@ -15089,7 +15527,7 @@
                 "gp_stack": "1.5m gp",
                 "items_needed": "cash stack, oak longbow, ghostspeak amulet, bucket of slime, thin snail, law runes, earth staff, water runes 5 iron bars, hammer, 2 undead chickens, mithril axe, holy symbol, hard leather, polished buttons, games necklace",
                 "skills_quests_met": "yes",
-                "total_time": "10d17h"
+                "total_time": "10d2h"
               }
             },
             {
@@ -15151,7 +15589,7 @@
                 "gp_stack": "1.5m gp",
                 "items_needed": "law runes, fire runes, air staff, death runes, earth runes, water runes, 2 crest pieces, swordfish, antipoison, lava eel, dramen staff, scorpion cage",
                 "skills_quests_met": "yes",
-                "total_time": "10d18h"
+                "total_time": "10d3h"
               }
             },
             {
@@ -15247,23 +15685,13 @@
                 "gp_stack": "1.5m gp",
                 "items_needed": "swordfish, prayer potions, (4+) energy potions, antipoisons, gold bar, ball of wool, lockpick, wind staff, chaos runes, law runes, water runes, rune axe, tinderbox, knife, oak log, big fishing net, bow string",
                 "skills_quests_met": "yes",
-                "total_time": "10d21h"
+                "total_time": "10d6h"
               }
             },
             {
               "content": [
                 {
-                  "text": "Minigame teleport to Shades of Mort’ton, buy a limestone (if you already have this from wintertodt skip it), a plank and 8 limestone bricks from Razmire (or do this after the quest), do Haunted Mine. If you have any poisoned weapon (or ammunition), use that to inflict poison on Treus Dayth to speed up the fight and make it much easier.",
-                  "formatting": {
-                    "fontSize": 12
-                  }
-                },
-                {
-                  "text": " ",
-                  "formatting": {}
-                },
-                {
-                  "text": "Collect ",
+                  "text": "Minigame teleport to Shades of Mort’ton, buy a limestone (if you already have this from wintertodt skip it), a plank and 8 limestone bricks from Razmire (or do this after the quest), do Haunted Mine. Collect ",
                   "formatting": {
                     "fontSize": 12
                   }
@@ -15288,7 +15716,7 @@
                 "gp_stack": "1.5m gp",
                 "items_needed": "Iban staff, death runes, fire runes, ball of wool, chisel, energy potions, prayer potions, swordfish, premade choc bombs, any poisoned weapon or ammunition",
                 "skills_quests_met": "yes",
-                "total_time": "10d21h"
+                "total_time": "10d6h"
               }
             },
             {
@@ -15319,7 +15747,7 @@
                 "gp_stack": "1.5m gp",
                 "items_needed": "cash stack, Iban staff, death runes, fire runes, games neck, fire feather, cooked lava eel, black platebody, black full helm, black platelegs (Black Arm Gang), chronicle",
                 "skills_quests_met": "yes",
-                "total_time": "10d22h"
+                "total_time": "10d7h"
               }
             },
             {
@@ -15393,6 +15821,10 @@
                   }
                 },
                 {
+                  "text": "Do Big Chompy Bird Hunting, save a raw chompy for later. Do Zogre Flesh Eaters (use dueling rings for speeding up the quest), killing Zogres along the way for Rag and Bone Man II. Make sure to unlock Uglug’s Stuffsies and buy 16 relicym’s balm (3), decant them into 12 4-dose potions. Use Crumble Undead for the Slash Bash fight. ",
+                  "formatting": {}
+                },
+                {
                   "text": "Buy and smelt ",
                   "formatting": {
                     "color": {
@@ -15419,11 +15851,26 @@
                   }
                 },
                 {
-                  "text": "or exactly as many as it takes to get to level 50) ",
+                  "text": "or exactly as many as it takes to get to level 50), 6 iron bars and 20 steel bars and",
                   "formatting": {}
                 },
                 {
-                  "text": "and make a(n inventory of) mithril bar(s), buying the ore if needed. Save a few hundred gold ",
+                  "text": " ",
+                  "formatting": {
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0
+                    },
+                    "fontSize": 12
+                  }
+                },
+                {
+                  "text": "27",
+                  "formatting": {}
+                },
+                {
+                  "text": " mithril bars, buying the ore if needed. Save a few hundred gold ",
                   "formatting": {
                     "color": {
                       "r": 0,
@@ -15483,23 +15930,268 @@
                       }
                     },
                     {
-                      "text": ", so if you had to boost to make one it would be nice to first head off to the God Wars dungeon (requires 70 ranging, unboostable) and use a droptrick to grab 5 or so in the Armadyl camp (don’t forget your god protection items!). Alternatively you can make several yourself.\n",
+                      "text": ", so if you had to boost to make one it would be nice to first head off to the God Wars dungeon (requires 70 ranging, unboostable) and use a droptrick to grab 5 or so in the Armadyl camp (don’t forget your god protection items!). Alternatively you can make several yourself. If you make these here you need extra mithril bars or you will not have enough later.\n",
                       "formatting": {}
                     }
                   ]
                 }
               ],
               "metadata": {
-                "gp_stack": "700k gp",
+                "gp_stack": "670k gp",
                 "items_needed": "780k gp, energy potions, gold gauntlets, ring of charos (a)",
                 "skills_quests_met": "yes",
-                "total_time": "11d9h"
+                "total_time": "10d18h"
               }
             },
             {
               "content": [
                 {
-                  "text": "Go to Rellekka (house teleport). ",
+                  "text": "Keep wearing your ring of charos (a). Teleport to Falador. Run south to Port Sarim. Start and complete the Pandemonium quest. Whenever sailing you get some XP and a speed boost for trimming sails, so try to consistently click the sail when there’s a burst of wind. You need the sail trimming xp to hit level 22 later. Do port courier tasks (between Pandemonium and Port Sarim) until level 14 sailing, aiming to finish the level at Port Sarim. You can multiskill alch or fletch while sailing as desired. Complete the following charting tasks along the way:\n",
+                  "formatting": {}
+                }
+              ],
+              "nestedContent": [
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "Look at the port task board in Port Sarim.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "Interact with the salvaging station in Port Sarim.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "Treacherous rock formation near Draynor Village.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "Spyglass to get a good view of the Wizards’ Tower from the north.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "Spyglass to get a good view of Karamja Shipyard from the east.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "Wreck of the Salty Grouper south west of Tutorial Island.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "Spyglass to get a good view of the Pandemonium from the cave entrance, also dig up the small key for the salvaging station schematic.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "Spyglass to admire Charin’ Charles McAtless in the cave on the Pandemonium, also mine 22 lead ore in the cave. Superheat 10 of them into 5 bars.\n",
+                      "formatting": {}
+                    }
+                  ]
+                }
+              ],
+              "metadata": {
+                "gp_stack": "670k gp",
+                "items_needed": "tbd",
+                "skills_quests_met": "yes",
+                "total_time": "10d19h"
+              }
+            },
+            {
+              "content": [
+                {
+                  "text": "If you were at Port Sarim, charter to the Pandemonium. Start Prying Times (bank to grab the items necessary on Pandemonium). Charter or sail back (if you’re sailing, complete another port task as well). Pick up the crate of looty and return to the Pandemonium, grabbing and completing a second courier task as well along the way. Charter to Port Sarim, run to Thurgo, get the crowbar, return to the Pandemonium. Board your raft and head to the sealed crate, also chart the wreck of the Pandemonium II and the crashed gnome glider to the west. Open the crate, sail to the Pandemonium docks and drink the drink. You can either kill the troll or just disembark your ship, complete Prying Times. Search a nearby crate for the waterlogged journal and read it to unlock the ability to make the Medallion of the Deep.\n",
+                  "formatting": {}
+                }
+              ],
+              "nestedContent": [],
+              "metadata": {
+                "gp_stack": "670k gp",
+                "items_needed": "tbd",
+                "skills_quests_met": "yes",
+                "total_time": "10d19h"
+              }
+            },
+            {
+              "content": [
+                {
+                  "text": "Chart around the area using the route described in this image, getting you to level 22 sailing as you arrive at Catherby ",
+                  "formatting": {}
+                },
+                {
+                  "text": "20260215OSRS14-22ChartingRoute.png",
+                  "url": "https://drive.google.com/file/d/15CWomw2T_Uwmk-_RepxFgnhiCXcG8DUc/view?usp=sharing",
+                  "isLink": true,
+                  "formatting": {
+                    "underline": true
+                  }
+                },
+                {
+                  "text": ". Do not forget the spyglass for Keep le Faye just north of the image. The start point is deep in the Lumbridge Basin, so make your way there first. Whenever charting, collect drinks in your inventory and only start drinking them after you have docked your boat at your destination, ",
+                  "formatting": {}
+                },
+                {
+                  "text": "https://oldschool.runescape.wiki/w/Sealed_crate",
+                  "formatting": {
+                    "underline": true,
+                    "color": {
+                      "r": 0.06666667,
+                      "g": 0.33333334,
+                      "b": 0.8
+                    },
+                    "url": "https://oldschool.runescape.wiki/w/Sealed_crate",
+                    "isLink": true
+                  }
+                },
+                {
+                  "text": " tells you which drinks have negative effects.\n",
+                  "formatting": {}
+                }
+              ],
+              "nestedContent": [],
+              "metadata": {
+                "gp_stack": "670k gp",
+                "items_needed": "tbd",
+                "skills_quests_met": "yes",
+                "total_time": "10d19h"
+              }
+            },
+            {
+              "content": [
+                {
+                  "text": "Start and complete Current Affairs in full. Note: for the current duck charting you do not have to follow the duck, you only need to set it loose and pick it up at the endpoint before it despawns, which is quite a generous timer. You can therefore combine this activity with other sailing in the area.\n",
+                  "formatting": {}
+                }
+              ],
+              "nestedContent": [],
+              "metadata": {
+                "gp_stack": "670k gp",
+                "items_needed": "tbd",
+                "skills_quests_met": "yes",
+                "total_time": "10d20h"
+              }
+            },
+            {
+              "content": [
+                {
+                  "text": "Buy a skiff, build an iron helm and an oak mast and linen sails on it. Buy 25 repair kits and put them in your cargo hold, using them whenever appropriate (keep in mind you can also repair your ship every time you are at a shipwright, which is recommended). Chart most of the Ardent Ocean using the route in red in ",
+                  "formatting": {}
+                },
+                {
+                  "text": "20260215OSRS24-30ChartingRoute.png",
+                  "url": "https://drive.google.com/file/d/1A3jE9E6wZxuh6cOvD6G1-Ym7CXoGnXDY/view?usp=sharing",
+                  "isLink": true,
+                  "formatting": {
+                    "underline": true
+                  }
+                },
+                {
+                  "text": ". The starting point is near Catherby. After reaching the Ruins of Unkah, drink the Bottle of slug’s mind balm last (it teleports you to Witchhaven), then run to Ardougne docks, charter a ship to Musa Point and recover your skiff. Then sail the orange route, visiting current duck spots. Dock at the Pandemonium.\n",
+                  "formatting": {}
+                }
+              ],
+              "nestedContent": [],
+              "metadata": {
+                "gp_stack": "650k gp",
+                "items_needed": "tbd",
+                "skills_quests_met": "yes",
+                "total_time": "10d20h"
+              }
+            },
+            {
+              "content": [
+                {
+                  "text": "If you are already level 31 sailing, upgrade your skiff with a teak hull. If not, sail south and complete the swordfish rank of the Tempor Tantrum to get the level, then return and upgrade the hull. Continue doing laps of Tempor Tantrum (unlock all difficulties, then do Marlin rank for xp) until at least 35,000 xp (level 39). Make sure to collect the stormy key, barrel stand and the Whirlpool surprises.\n",
+                  "formatting": {}
+                }
+              ],
+              "nestedContent": [],
+              "metadata": {
+                "gp_stack": "650k gp",
+                "items_needed": "tbd",
+                "skills_quests_met": "yes",
+                "total_time": "10d21h"
+              }
+            },
+            {
+              "content": [
+                {
+                  "text": "Using the route in ",
+                  "formatting": {}
+                },
+                {
+                  "text": "20260215OSRS39-45ChartingRoute.png",
+                  "url": "https://drive.google.com/file/d/1xF2WehguS3ax_60lmh_JkXvqsGbdMmRp/view?usp=sharing",
+                  "isLink": true,
+                  "formatting": {
+                    "underline": true
+                  }
+                },
+                {
+                  "text": "(starting at the Tempor Tantrum), chart a good portion of the Unquiet Ocean. Once you reach the end of this trek, make sure your ship is stationary before drinking the bottle of alone at sea (a 75 second cutscene will play while your ship keeps moving if it’s not stationary!), then teleport out, minigame teleport to Port Khazard, recover your skiff, build an inoculation station and complete the mermaid diving charts in the Strait of Khazard and Gu’tanoth Bay. This completes the charting for the Ardent Ocean. Teleport to your POH and charter a ship to the Pandemonium, then collect the Ardent Ocean xp reward and the kraken ink stout (buy 25 of them) from Chartin’ Charles McAtless. Buy 48 whirlpool surprises from the Pandemonium pub. Build a keg on your skiff and fill it with whirlpool surprise.\n",
+                  "formatting": {}
+                }
+              ],
+              "nestedContent": [
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "When at Dognose Island, dock there and open the rusty chest to get a medallion fragment.\n",
+                      "formatting": {}
+                    }
+                  ]
+                }
+              ],
+              "metadata": {
+                "gp_stack": "620k gp",
+                "items_needed": "tbd",
+                "skills_quests_met": "yes",
+                "total_time": "10d21h"
+              }
+            },
+            {
+              "content": [
+                {
+                  "text": "Teleport to Falador, smelt your lead ore into 11 bars. Pay the estate agent to move your house to Rellekka. House teleport.",
+                  "formatting": {}
+                },
+                {
+                  "text": " ",
                   "formatting": {
                     "color": {
                       "r": 0,
@@ -15552,7 +16244,7 @@
                   "formatting": {}
                 },
                 {
-                  "text": ". Alch gold bars while doing this (you’ll get plenty of time to alch during Rex later too). ",
+                  "text": ". ",
                   "formatting": {
                     "color": {
                       "r": 0,
@@ -15579,10 +16271,10 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "620k gp",
-                "items_needed": "cash stack, dramen staff, nature runes, fire runes, gold bars, rune sword, amulet of strength, berserker helm, etc.",
+                "gp_stack": "550k gp",
+                "items_needed": "cash stack, dramen staff, rune sword, amulet of strength, berserker helm, etc.",
                 "skills_quests_met": "yes",
-                "total_time": "11d10h"
+                "total_time": "11d0h"
               }
             },
             {
@@ -15623,10 +16315,10 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "525k gp",
+                "gp_stack": "450k gp",
                 "items_needed": "rune sword, amulet of strength, berserker helm, etc. (henceforth ‘melee gear’)",
                 "skills_quests_met": "yes",
-                "total_time": "11d12h"
+                "total_time": "11d1h"
               }
             },
             {
@@ -15834,10 +16526,10 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "720k gp",
+                "gp_stack": "650k gp",
                 "items_needed": "1.1k gold bars, nature runes, granite body, rune platelegs, Iban staff, death runes, fire runes, berserker helm, amulet of magic, antipoisons, premade chocolate bombs(/other high healing food, if you have any), etc. (standard Rex gear), air staff, earth runes, water runes, fire runes, chaos runes, bronze sword, steel arrow, molten glass, tinderbox, hammer, 60 steel nails, 1 swamp tar, scorpion cage",
                 "skills_quests_met": "yes",
-                "total_time": "11d20h"
+                "total_time": "11d9h"
               }
             },
             {
@@ -15916,10 +16608,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "720k gp",
+                "gp_stack": "650k gp",
                 "items_needed": "cash stack, melee gear (incl. torso/ring now), Commorb, swamp paste, 20 pure essence, chisel, necklace of passage, law runes, water runes, air runes, ardougne cloak 1, bird snare, rune pickaxe",
                 "skills_quests_met": "yes",
-                "total_time": "12d9h"
+                "total_time": "11d22h"
               }
             },
             {
@@ -16097,10 +16789,10 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "150k",
+                "gp_stack": "80k",
                 "items_needed": "cash stack, dramen staff, iron bar, rune pickaxe, rune axe, gold ring (BH runs), cake or oak shortbow (your choice), energy potions, melee gear, prayer potions, swordfish",
                 "skills_quests_met": "yes",
-                "total_time": "12d10h"
+                "total_time": "11d23h"
               }
             },
             {
@@ -16159,10 +16851,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "150k",
+                "gp_stack": "80k",
                 "items_needed": "cash stack, melee gear, swordfish, prayer potions, energy potions, rune pickaxe, mine key",
                 "skills_quests_met": "yes",
-                "total_time": "12d11h"
+                "total_time": "12d0h"
               }
             }
           ],
@@ -16264,7 +16956,7 @@
                   "level": 1,
                   "content": [
                     {
-                      "text": "If you prefer to do this as a low effort/afk activity you may instead choose to weave the fishing in during other steps (instead of grinding this all at once). The levels are not needed until step 64 of this chapter",
+                      "text": "If you prefer to do this as a low effort/afk activity you may instead choose to weave the fishing in during other steps (instead of grinding this all at once). The levels are not needed until step 83 of this chapter",
                       "formatting": {}
                     },
                     {
@@ -16293,10 +16985,10 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "60k gp",
+                "gp_stack": "20k gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
-                "total_time": "15d10h"
+                "total_time": "14d23h"
               }
             },
             {
@@ -16344,7 +17036,22 @@
                   }
                 },
                 {
-                  "text": ". Make a silvthrill rod at the Neitiznot furnace. ",
+                  "text": ". ",
+                  "formatting": {
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0
+                    },
+                    "fontSize": 12
+                  }
+                },
+                {
+                  "text": "Turn 5 mithril bars into 75 mithril nails at the Jatiszo anvils during the quest. ",
+                  "formatting": {}
+                },
+                {
+                  "text": "Make a silvthrill rod at the Neitiznot furnace. ",
                   "formatting": {
                     "color": {
                       "r": 0,
@@ -16388,10 +17095,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "105k gp",
+                "gp_stack": "60k gp",
                 "items_needed": "cash stack, Fremennik boots 1, 7 coal, 9 ropes, knife, rune axe, hammer, bronze nail, needle, 2 thread, melee gear, swordfish/premade choc bombs, prayer potions, cut sapphire, mithril bar, silver bar, rod mould, cosmic rune, water runes",
                 "skills_quests_met": "yes",
-                "total_time": "15d10h"
+                "total_time": "14d23h"
               }
             },
             {
@@ -16403,16 +17110,16 @@
                   }
                 },
                 {
-                  "text": " (optional: make more than one lunar staff for cosmetic purposes). Remember to do your hourlies and grow cats whenever convenient.\n",
+                  "text": " (optional: make more than one lunar staff for cosmetic purposes). While on the Lady Zay, collect at least 45 swamp tar. Remember to do your hourlies and grow cats whenever convenient.\n",
                   "formatting": {}
                 }
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "105k gp",
+                "gp_stack": "60k gp",
                 "items_needed": "tinderbox, bullseye lantern (might still be a sapphire lantern from Tears of Guthix, just swap it out), melee gear, swordfish, energy potions, prayer potions, clean guam, clean marrentill, pestle and mortar, dramen staff",
                 "skills_quests_met": "yes",
-                "total_time": "15d11h"
+                "total_time": "15d0h"
               }
             },
             {
@@ -16434,10 +17141,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "105k gp",
+                "gp_stack": "60k gp",
                 "items_needed": "cat, 9 stews, tiara, mind talisman, 10 pure essence, binding necklace, earth talisman, earth runes, dramen staff, blank air rune, blank water rune, blank earth rune, blank fire rune, blank mind rune",
                 "skills_quests_met": "yes",
-                "total_time": "15d12h"
+                "total_time": "15d1h"
               }
             },
             {
@@ -16479,10 +17186,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "75k gp",
+                "gp_stack": "30k gp",
                 "items_needed": "law runes, air runes, earth runes, water runes, seal of passage, cash stack, bowl of water, rune pickaxe, hammer, needle, 2 thread, 4 suqah hide, tinderbox, spade, energy potions, prayer potions, swordfish, small pouch, medium pouch, large pouch, cosmic runes, astral runes, staff of air, chisel, abyssal book.",
                 "skills_quests_met": "yes",
-                "total_time": "15d13h"
+                "total_time": "15d2h"
               }
             },
             {
@@ -16526,16 +17233,14 @@
                       "b": 0
                     }
                   }
-                },
-                {
-                  "text": "Total time:"
                 }
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "75k gp",
+                "gp_stack": "30k gp",
                 "items_needed": "bowl of hot water, 1 harralander, 2 guam, 2 marrentill, energy potions, prayer potions, air staff, law runes, water runes, scorpion cage",
-                "skills_quests_met": "yes"
+                "skills_quests_met": "yes",
+                "total_time": "15d2h"
               }
             },
             {
@@ -16594,10 +17299,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "75k gp",
+                "gp_stack": "30k gp",
                 "items_needed": "cash stack, emerald lantern, lantern lens, tinderbox, 10 oak planks, 10 steel nails, hammer, spade, dramen staff, butterfly net, butterfly jar, teasing stick, knife, any log, water staff, law runes, cat, ardougne cloak 1",
                 "skills_quests_met": "yes",
-                "total_time": "15d14h"
+                "total_time": "15d3h"
               }
             },
             {
@@ -16675,10 +17380,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "75k gp",
+                "gp_stack": "30k gp",
                 "items_needed": "cash stack, rune axe, earth runes (or staff), air runes (or staff), death runes, raw karambwanji, anti-dragon shield, melee gear, swordfish, energy potions, prayer potions, antipoison, steel spear, small fishing net, 4-dose agility potion, tinderbox, necklace of passage (for two sections ahead)",
                 "skills_quests_met": "yes",
-                "total_time": "15d15h"
+                "total_time": "15d4h"
               }
             },
             {
@@ -16722,10 +17427,10 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "77k gp",
+                "gp_stack": "30k gp",
                 "items_needed": "cash stack, karambwan vessel, Iban staff, death runes, fire runes, 2+ logs, tinderbox, noted semi-precious gems (sell to Gabooty for trading sticks), banana-rum, seaweed, monkey skin, jogre bones, raw karambwanji, pestle and mortar, teasing stick, knife, necklace of passage (next)",
                 "skills_quests_met": "yes",
-                "total_time": "15d16h"
+                "total_time": "15d5h"
               }
             },
             {
@@ -16769,10 +17474,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "77k gp",
+                "gp_stack": "30k gp",
                 "items_needed": "necklace of passage",
                 "skills_quests_met": "yes",
-                "total_time": "15d16h"
+                "total_time": "15d5h"
               }
             },
             {
@@ -16816,10 +17521,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "77k gp",
+                "gp_stack": "30k gp",
                 "items_needed": "Dueling ring (next section)",
                 "skills_quests_met": "yes",
-                "total_time": "15d16h"
+                "total_time": "15d5h"
               }
             },
             {
@@ -16893,10 +17598,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "77k gp",
+                "gp_stack": "30k gp",
                 "items_needed": "cash stack, waterskins, dueling ring, Camulet, stone scarab, air runes (or staff), death runes, fire runes (or staff), swordfish, prayer potions, antipoison, light source, catspeak amulet",
                 "skills_quests_met": "yes",
-                "total_time": "15d17h"
+                "total_time": "15d6h"
               }
             },
             {
@@ -16927,7 +17632,7 @@
                   "formatting": {}
                 },
                 {
-                  "text": "Do Big Chompy Bird Hunting, save a raw chompy for later. Catch a spined larupia for the diary. Kill ",
+                  "text": "Catch a spined larupia for the diary. Kill ",
                   "formatting": {
                     "color": {
                       "r": 0,
@@ -16944,10 +17649,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "75k gp",
+                "gp_stack": "30k gp",
                 "items_needed": "cash stack, stodgy mattress, semi-precious gems, sapphires, Ardy Cloak 1, dramen staff, teasing stick, knife, regular logs, hammer, chisel, melee gear, dueling ring, energy potions, games necklace (next)",
                 "skills_quests_met": "yes (follow wiki steps to obtain the remaining items during the quest)",
-                "total_time": "15d18h"
+                "total_time": "15d7h"
               }
             },
             {
@@ -17006,10 +17711,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "75k gp",
+                "gp_stack": "30k gp",
                 "items_needed": "stodgy mattress, games necklace, catspeak amulet, hellcat, 4 cheese, empty vial, 2 red spider’s eggs, kwuarm, marrentill, unicorn horn dust, bucket of milk, karambwanji or other fish (for cat), limpwurt root, law runes, air runes, fire runes",
                 "skills_quests_met": "yes",
-                "total_time": "15d18h"
+                "total_time": "15d7h"
               }
             },
             {
@@ -17038,10 +17743,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "75k gp",
+                "gp_stack": "30k gp",
                 "items_needed": "law runes, earth runes, air runes, two molten glass, plank, silk, steel bar, hellcat, catspeak amulet, pot, weeds, tinderbox, golden cannonball, dwarven lore book (for the third page)",
                 "skills_quests_met": "yes",
-                "total_time": "15d19h"
+                "total_time": "15d8h"
               }
             },
             {
@@ -17102,10 +17807,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "75k gp",
+                "gp_stack": "30k gp",
                 "items_needed": "doctor’s hat, desert shirt/robe, vial of water, law runes, water staff, melee gear + rune pickaxe, prayer potions, hammer, ring of charos(a), Ardy Cloak 1, penguin suit",
                 "skills_quests_met": "yes",
-                "total_time": "15d19h"
+                "total_time": "15d8h"
               }
             },
             {
@@ -17138,10 +17843,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "75k gp",
+                "gp_stack": "30k gp",
                 "items_needed": "law runes, air staff, hammer, dueling ring, melee gear, swordfish, prayer potions, energy potions, dwarven stout (on table), 2 soft clay, fire runes, herbal tincture (reclaim from Apothecary instead), 5 pigeon cages, fancy/fighter boots (to imbue the sceptre).",
                 "skills_quests_met": "yes (listen to the wiki when it tells you to pick up items to save time later)",
-                "total_time": "15d20h"
+                "total_time": "15d9h"
               }
             },
             {
@@ -17200,10 +17905,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "75k gp",
+                "gp_stack": "30k gp",
                 "items_needed": "catspeak amulet, law runes, air staff, earth runes (all for next section)",
                 "skills_quests_met": "yes",
-                "total_time": "15d20h"
+                "total_time": "15d9h"
               }
             },
             {
@@ -17264,10 +17969,10 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "74k gp",
+                "gp_stack": "30k gp",
                 "items_needed": "penguin suit, evil stew, air runes, water rune, law rune",
                 "skills_quests_met": "yes (listen to the wiki when it tells you to steal a bell and grab items)",
-                "total_time": "15d20h"
+                "total_time": "15d9h"
               }
             },
             {
@@ -17326,10 +18031,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "74k gp",
+                "gp_stack": "30k gp",
                 "items_needed": "cash stack, chicken cages, blunt axe, hellcat, catspeak amulet, snake charm, charos(a), bucket of milk, egg, pot of flour, cake tin",
                 "skills_quests_met": "yes",
-                "total_time": "15d20h"
+                "total_time": "15d9h"
               }
             },
             {
@@ -17383,10 +18088,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "74k gp",
+                "gp_stack": "30k gp",
                 "items_needed": "cash stack, ring of charos(a), sharpened axe, penguin suit, swamp tar, 5 feathers, mission report, mahogany plank, soft leather, cowbell (stolen in Step 57), swordfish, melee gear, prayer potions, spade, Ectophial, ghostspeak amulet, sapphire amulet, Fremennik boots 1, necklace of passage, law runes, water staff, enchanted key, dueling ring (to get to Castle Wars for the first step in Making History, but also rebank at Ferox), air runes, earth rune",
-                "skills_quests_met": "no (earlier items only)",
-                "total_time": "15d21h"
+                "skills_quests_met": "no",
+                "total_time": "15d10h"
               }
             },
             {
@@ -17441,10 +18146,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "74k gp",
+                "gp_stack": "30k gp",
                 "items_needed": "Ardy Cloak 1, dramen staff, energy pots, rope, waterskins, Camulet, hellcat, catspeak amulet",
                 "skills_quests_met": "yes",
-                "total_time": "15d21h"
+                "total_time": "15d10h"
               }
             },
             {
@@ -17477,16 +18182,30 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "93k gp",
+                "gp_stack": "50k gp",
                 "items_needed": "cash stack (only take 7.5k into Wildy), 3 gold bars, slash item/weapon, hammer, pickaxe (for Wildy med diary, so addy instead of rune for example), melee gear, prayer pots, swordfish",
                 "skills_quests_met": "yes",
-                "total_time": "15d21h"
+                "total_time": "15d10h"
               }
             },
             {
               "content": [
                 {
-                  "text": "MLM for coal and gem bag (repair the strut along the way for the diary). Do low level ",
+                  "text": "MLM for coal and gem bag (repair the strut along the way for the diary). Make sure ",
+                  "formatting": {}
+                },
+                {
+                  "text": "not",
+                  "formatting": {
+                    "bold": true
+                  }
+                },
+                {
+                  "text": " to use your celestial ring for this - it it bugged and reduces the amount of nuggets you get. ",
+                  "formatting": {}
+                },
+                {
+                  "text": "Do low level ",
                   "formatting": {}
                 },
                 {
@@ -17536,11 +18255,11 @@
                   "level": 1,
                   "content": [
                     {
-                      "text": "Similar to the barbarian fishing you can choose to spread this out over multiple steps, although this time you need at least 72 mining by step 64 ",
+                      "text": "Similar to the barbarian fishing you can choose to spread this out over multiple steps, although this time you need at least 72 mining by step 71 ",
                       "formatting": {}
                     },
                     {
-                      "text": "and you need to have completed MLM by step 73.\n",
+                      "text": "and you need to have completed MLM by step 84.\n",
                       "formatting": {}
                     }
                   ]
@@ -17771,9 +18490,9 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "280k gp",
+                "gp_stack": "240k gp",
                 "skills_quests_met": "yes",
-                "total_time": "16d22h"
+                "total_time": "16d11h"
               }
             },
             {
@@ -17899,7 +18618,7 @@
                   "level": 1,
                   "content": [
                     {
-                      "text": "Make the Fire of Nourishment (three Fires of Eternal Light optional), grab an iron pickaxe, mine all the basalt (using your rune pickaxe) and salts for all the fires, make 100 Stony basalt and 100 Icy basalt. In total this requires 200 basalt, 1050 Efh, 1000 Urt and 1300 Te salt.\n",
+                      "text": "Make the Fire of Nourishment (three Fires of Eternal Light optional), grab an iron pickaxe, mine all the basalt (using your rune pickaxe) and salts for all the fires and two eternal braziers, make 100 Stony basalt and 100 Icy basalt. In total this requires 200 basalt, 1550 Efh, 1500 Urt and 1800 Te salt. You can make the teleports right there in the mine, save the rest of the salts for future uses.\n",
                       "formatting": {}
                     }
                   ]
@@ -17915,10 +18634,10 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "305k gp",
+                "gp_stack": "260k gp",
                 "items_needed": "cash stack, 10 mist runes, 10 lava runes, 5 blood runes, airtight pot, rune pickaxe, rune axe, tinderbox, hammer, ring of charos(a), dramen staff, Ardy Cloak 1, melee gear, prayer pots, swordfish, yellow dye, swamp tar, necklace of passage, rope, energy pots, teasing stick, box trap, rabbit snare, law runes, soul runes",
                 "skills_quests_met": "yes",
-                "total_time": "17d1h"
+                "total_time": "16d14h"
               }
             },
             {
@@ -18076,10 +18795,10 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "305k gp",
+                "gp_stack": "260k gp",
                 "items_needed": "knife, teak log, barbarian rod, feathers, 2-dose potions",
                 "skills_quests_met": "yes",
-                "total_time": "22d4h"
+                "total_time": "21d17h"
               }
             },
             {
@@ -18103,7 +18822,7 @@
                   "level": 1,
                   "content": [
                     {
-                      "text": "(redirected) POH tab to Brimhaven, take the travel cart to Shilo village. Resume Legends’ Quest all the way to the final step (have obtained the totem pole). While in the jungle chop a teak and mahogany log, collect a palm leaf (chop a palm tree) five times (drop and pick up), make and eat an oomlie wrap (kill an oomlie for food, use palm leaf, cook and eat), collect a vanilla pod along the way for RFD/Sir Amik Varze and kill a deathwing inside the Viyeldi caves for the diary. Head to the northwest of Tai Bwo Wannai village and light a fire on the coast for RFD/Skrach, take the boat back to Rantz and prepare a cooked jubbly.\n",
+                      "text": "Ardy teleport, boat to to Brimhaven, take the travel cart to Shilo village. Resume Legends’ Quest all the way to the final step (have obtained the totem pole). While in the jungle chop a teak and mahogany log, collect a palm leaf (chop a palm tree) five times (drop and pick up), make and eat an oomlie wrap (kill an oomlie for food, use palm leaf, cook and eat), collect a vanilla pod along the way for RFD/Sir Amik Varze and kill a deathwing inside the Viyeldi caves for the diary. Head to the northwest of Tai Bwo Wannai village and light a fire on the coast for RFD/Skrach, take the boat back to Rantz and prepare a cooked jubbly.\n",
                       "formatting": {}
                     }
                   ]
@@ -18137,10 +18856,10 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "180k gp",
+                "gp_stack": "130k gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
-                "total_time": "22d9h"
+                "total_time": "21d22h"
               }
             },
             {
@@ -18182,7 +18901,7 @@
                   "level": 1,
                   "content": [
                     {
-                      "text": "If you haven’t already, go to either the PVP Arena or to NMZ and imbue your berserker ring and salve amulet.\n",
+                      "text": "If you haven’t already, go to either the PVP Arena or to NMZ and imbue your berserker ring and salve amulet. Below are some general resources, but at these stats there’s a better method outlined below.\n",
                       "formatting": {}
                     }
                   ]
@@ -18381,17 +19100,17 @@
                   "level": 1,
                   "content": [
                     {
-                      "text": "Go to NMZ and collect enough points (using the above guide) for redirection scrolls. From here on you have redirected POH tabs for herb runs, tree runs and general use.\n",
+                      "text": "Go to NMZ and collect 200k extra points, using all to buy redirection scrolls. Disable Desert Treasure (and, if you want a more AFK experience, also Family Crest). If you need other imbues, stay for longer to get those as well. From here on you have redirected POH tabs for herb runs, tree runs and general use. When you run out, come back and get more.\n",
                       "formatting": {}
                     }
                   ]
                 }
               ],
               "metadata": {
-                "gp_stack": "173k gp",
+                "gp_stack": "120k gp",
                 "items_needed": "cash stack, cut diamond, melee gear (now incl. dscim/DDS), mithril armour set, prayer potions, stat-boosting potions, cheese potatoes (buy in guild)",
                 "skills_quests_met": "yes",
-                "total_time": "22d17h"
+                "total_time": "22d6h"
               }
             },
             {
@@ -18475,10 +19194,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "173k gp",
+                "gp_stack": "120k gp",
                 "items_needed": "melee gear, cheese potatoes, stat-boosting potions, prayer potions, a defence potion (3 dose), volcanic sulphur, molten glass, dark essence block, an axe, fire bolt runes",
                 "skills_quests_met": "yes",
-                "total_time": "22d20h"
+                "total_time": "22d9h"
               }
             },
             {
@@ -18561,7 +19280,7 @@
                   "level": 1,
                   "content": [
                     {
-                      "text": "HCIM: you can opt to train through calcified rocks in Varlamore instead, offering blessed bone shards at the liberation bowl. Note that this scales with your mining level, so optionally you could choose to do more mining (sandstone, granite or gem rocks) first.\n",
+                      "text": "HCIM: you can opt to train through calcified rocks in Varlamore instead, offering blessed bone shards at the libation bowl. Note that this scales with your mining level, so optionally you could choose to do more mining (sandstone, granite or gem rocks) first.\n",
                       "formatting": {
                         "italic": true,
                         "color": {
@@ -18575,10 +19294,10 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "173k gp",
+                "gp_stack": "120k gp",
                 "items_needed": "melee gear (as mentioned), looting bag, cheese potatoes, stat-boosting pots, runes for thralls",
                 "skills_quests_met": "yes",
-                "total_time": "23d12h"
+                "total_time": "23d1h"
               }
             },
             {
@@ -18629,7 +19348,7 @@
                   "level": 2,
                   "content": [
                     {
-                      "text": "If you do not have enough fossils for two display cases postpone this to step 72.\n",
+                      "text": "If you do not have enough fossils for two display cases postpone this to step 79.\n",
                       "formatting": {
                         "italic": true
                       }
@@ -18638,10 +19357,10 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "173k gp",
+                "gp_stack": "120k gp",
                 "items_needed": "1.4k bones, melee gear (for PC)",
                 "skills_quests_met": "yes",
-                "total_time": "23d12h"
+                "total_time": "23d1h"
               }
             },
             {
@@ -18662,13 +19381,13 @@
               "metadata": {
                 "gp_stack": "1.8m gp",
                 "items_needed": "green dragonhides, coins, nature runes, staff of fire, maple logs, knife, steel nails, feathers, Kharedst’s memoirs, log basket",
-                "total_time": "23d16h"
+                "total_time": "23d5h"
               }
             },
             {
               "content": [
                 {
-                  "text": "You should be level 51 (or higher) slayer. Make sure you have finished the Curse of the Empty Lord miniquest (if you haven’t, do it now, putting the lamp on slayer). Teleport to Varrock, make sure to grab the Dragon’hai history book from the Varrock Palace library if you don’t already have it, pray at the altar in the palace with smite active. Run east to the quetzal to go to Varlamore and do At First Light (note: the hunter rumours are currently not efficient, but if you want the rewards you can go for them at any time after this quest). During At First Light catch a Sunlight antelope (east end of the island, requires level 72 hunter, a teasing stick, knife and logs - grab a Trapper’s tipple or two at the hunter’s guild for a +2 boost if needed) and kill a jaguar for their fur. At the hunter’s guild buy two mixed hide bases, and either pay Pellem to have the furs made into mixed hide boots (your best ranged boots for now) and a mixed hide cape (your best melee cape for now) or boost your crafting level if you have a spare mushroom pie to do it yourself. After this start and complete Perilous Moons (for the fights your dragon scimitar is fine, even for ice. Use the moss lizards and moonlight potions for supplies) and The Heart of Darkness. At the end of the quest travel to Tal Teklan (e.g. with the quetzal system). Buy four willow longbows at Arcuani’s Archery Supplies. If you haven’t done Scrambled! yet, do it now. Travel to Auburnvale (e.g. using the boat system). Start and complete Shadows of Custodia. Teleport out. Slay a Brine rat to complete the Fremennik medium diary, putting the lamp on herblore. Grab a rope, salve teleport, dip your enchanted silvthrill rod in the well to make the Rod of Ivandis and complete In Aid of the Myreque, Darkness of Hallowvale, A Taste of Hope and Sins of the Father (all lamps on herblore). Use the Efaritay’s aid during the Vanstrom Klause fight in Sins of the Father - you should only need one ring, the second is spare in case you die or run out of charges.\n",
+                  "text": "You should be level 51 (or higher) slayer. Make sure you have finished the Curse of the Empty Lord miniquest (if you haven’t, do it now, putting the lamp on slayer). Teleport to Varrock, make sure to grab the Dragon’hai history book from the Varrock Palace library if you don’t already have it, pray at the altar in the palace with smite active. Buy 20,000 air runes (if you already have these you can ignore this), then run through  the east gate to the quetzal to go to Varlamore and do At First Light (note: the hunter rumours are currently not efficient, but if you want the rewards you can go for them at any time after this quest). During At First Light catch a Sunlight antelope (east end of the island, requires level 72 hunter, a teasing stick, knife and logs - grab a Trapper’s tipple or two at the hunter’s guild for a +2 boost if needed) and kill a jaguar for their fur. At the hunter’s guild buy two mixed hide bases, and either pay Pellem to have the furs made into mixed hide boots (your best ranged boots for now) and a mixed hide cape (your best melee cape for now) or boost your crafting level if you have a spare mushroom pie to do it yourself. After this start and complete Perilous Moons (for the fights your dragon scimitar is fine, even for ice. Use the moss lizards and moonlight potions for supplies) and The Heart of Darkness. At the end of the quest travel to Tal Teklan (e.g. with the quetzal system). Buy four willow longbows at Arcuani’s Archery Supplies. If you haven’t done Scrambled! yet, do it now. Travel to Auburnvale (e.g. using the boat system). Start and complete Shadows of Custodia. Teleport out. Slay a Brine rat to complete the Fremennik medium diary, putting the lamp on herblore. Grab a rope, salve teleport, dip your enchanted silvthrill rod in the well to make the Rod of Ivandis and complete In Aid of the Myreque, Darkness of Hallowvale, A Taste of Hope and Sins of the Father (all lamps on herblore). Use the Efaritay’s aid during the Vanstrom Klause fight in Sins of the Father - you should only need one ring, the second is spare in case you die or run out of charges.\n",
                   "formatting": {}
                 }
               ],
@@ -18677,7 +19396,7 @@
                   "level": 1,
                   "content": [
                     {
-                      "text": "We will continue lamping slayer to level 58 for access to Cave Horrors, and after that put all lamps on herblore instead. You may choose to lamp more/less slayer depending on personal preference. There is more than enough lamp xp.\n",
+                      "text": "We will continue lamping slayer to level 58 for access to Cave Horrors (mind the quest xp still coming up, about 30k total from here), and after that put all lamps on herblore instead. You may choose to lamp more/less slayer depending on personal preference. There is more than enough lamp xp.\n",
                       "formatting": {}
                     }
                   ]
@@ -18706,10 +19425,102 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "1.8m gp",
+                "gp_stack": "1.7m gp",
                 "items_needed": "law runes, soul runes, silvthrill rod, rope, dramen staff, plank, 8 nails, hammer",
                 "skills_quests_met": "yes",
-                "total_time": "24d3h"
+                "total_time": "23d16h"
+              }
+            },
+            {
+              "content": [
+                {
+                  "text": "Explorer’s ring teleport and run to Port Sarim to recruit Jobless Jim. You can set Jim to man the ship and trim the sails, reducing the xp from trimming by 50% but making sailing more convenient. Charter to the Pandemonium. Take your skiff to the starting point of Troubled Tortugans and start and complete the quest in full. While on the Great Conch collect the spyglass and strange apple tree charter on the isle. Next do port courier tasks to Summer Shore until level 50 sailing (",
+                  "formatting": {}
+                },
+                {
+                  "text": "Sailing training - OSRS Wiki",
+                  "formatting": {
+                    "underline": true,
+                    "color": {
+                      "r": 0.06666667,
+                      "g": 0.33333334,
+                      "b": 0.8
+                    },
+                    "url": "https://oldschool.runescape.wiki/w/Sailing_training#Levels_46-55:_Summer_Shore",
+                    "isLink": true
+                  }
+                },
+                {
+                  "text": "), completing the charting of the Unquiet Ocean in the process (the Sea of Shells after level 47). You can collect the ocean completion xp bonus (6k xp) to get to level 50. Once you hit level 50 (optional: keep going to level 51/52/53 instead, to reduce or eliminate the need for boosting while salvaging), use a dueling ring and run south all the way to the desert mining camp, then run out and recruit Ex-Captain Siad (don’t forget the key to the camp). Next, book of the dead teleport to Piscarillius (or charter if you were at Pandemonium for the xp bonus), recover your skiff here and sail south to Chinchompa Island. Chart the charred remains of a table and open the lockbox to get (and read) the salvaging station schematic. Sail to Port Roberts and dock there.\n",
+                  "formatting": {}
+                }
+              ],
+              "nestedContent": [
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "When at the Onyx Crest, dock there and dig to find the small key for the ",
+                      "formatting": {}
+                    },
+                    {
+                      "text": "Lost schematics - OSRS Wiki",
+                      "formatting": {
+                        "underline": true,
+                        "color": {
+                          "r": 0.06666667,
+                          "g": 0.33333334,
+                          "b": 0.8
+                        },
+                        "url": "https://oldschool.runescape.wiki/w/Lost_schematics",
+                        "isLink": true
+                      }
+                    },
+                    {
+                      "text": " and kill pirates to get a medallion fragment.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "Make sure to only drink the bottle of the way home (which will teleport you to your POH and your ship to Port Sarim) when it’s convenient - you can use this to set up a courier task more easily.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "Coral farming starts here. This is a worthwhile activity, creating super hunter potions and/or armadyl brews for herblore xp. From here on include coral in your farm runs, but only with attas active and 99 farming! Paying for protection is allegedly not worth it. You can visit the location by chartering to The Summer Shore, then taking the small boat to the northeast side of the island, then diving down. The first time you are down there search the coral on the west side to find a medallion fragment.\n",
+                      "formatting": {}
+                    }
+                  ]
+                }
+              ],
+              "metadata": {
+                "gp_stack": "1.7m gp",
+                "items_needed": "tbd",
+                "skills_quests_met": "yes",
+                "total_time": "23d18h"
+              }
+            },
+            {
+              "content": [
+                {
+                  "text": "Buy 80 lead ore. Steal from the silver stall to get a medallion fragment. Buy a sloop and build two kegs (fill one with whirlpool surprise and one with kraken ink stout), a salvaging station and two mithril salvaging hooks. Assign your two crewmembers to your boat. Sail your sloop to the large shipwrecks far south - do not go out of your way for charting with your slow sloop - north of the Isle of Serpents. Bring four empty beer glasses, a log basket and seed box (if you have them), and optionally methods to 1.5t the salvaging. Salvage until level 55 sailing, boosting sailing where necessary (it’s technically good to boost even if you have level 53 already). Your goal is to collect several hemp and cotton seeds for farming. Plant the hemp at your earliest convenience, making sure to have Attas up and using ultracompost to harvest at least 40 hemp in total.\n",
+                  "formatting": {}
+                }
+              ],
+              "nestedContent": [],
+              "metadata": {
+                "gp_stack": "1.7m gp",
+                "items_needed": "tbd",
+                "skills_quests_met": "yes",
+                "total_time": "23d20h"
               }
             },
             {
@@ -18803,7 +19614,7 @@
                   "level": 1,
                   "content": [
                     {
-                      "text": "Buy an upgraded device from Ava at level 50 (worth leaving for).\n",
+                      "text": "Buy an upgraded device from Ava at level 50 (worth leaving for) and collect and read the Ballistic attractor schematic.\n",
                       "formatting": {}
                     }
                   ]
@@ -18833,8 +19644,8 @@
                       "formatting": {}
                     },
                     {
-                      "text": "OSRS Pure Chinning Guide (Maximizing XP rates)",
-                      "url": "https://www.youtube.com/watch?v=0kUYAVc4QVg",
+                      "text": "Chinning Guide MM1 OSRS (600k XP P/H)",
+                      "url": "https://www.youtube.com/watch?v=bOa3WDea8lQ",
                       "isLink": true,
                       "formatting": {
                         "underline": true
@@ -18871,7 +19682,25 @@
                       "formatting": {}
                     }
                   ]
-                },
+                }
+              ],
+              "metadata": {
+                "gp_stack": "1.6m gp",
+                "items_needed": "tbd",
+                "skills_quests_met": "yes",
+                "total_time": "24d2h"
+              }
+            },
+            {
+              "content": [
+                {
+                  "text": "Read this step in its entirety carefully. This step contains the Hallowed Sepulchre grind to level 82 agility.\n",
+                  "formatting": {
+                    "bold": true
+                  }
+                }
+              ],
+              "nestedContent": [
                 {
                   "level": 1,
                   "content": [
@@ -19065,7 +19894,7 @@
                   "level": 1,
                   "content": [
                     {
-                      "text": "After Misc is up and running, buy arrow shafts and headless arrows (in smaller chunks) to get to a total of 1 million headless arrows through fletchpalchre.\n",
+                      "text": "After Misc is up and running, buy arrow shafts(/cut them from maples) and buy feathers (in smaller chunks) to get to a total of 1 million headless arrows through fletchpalchre.\n",
                       "formatting": {}
                     }
                   ]
@@ -19142,21 +19971,11 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "3.9m gp",
+                "gp_stack": "3.8m gp",
                 "items_needed": "green/blue d’hides, box traps, knife, teak log, salve amulet(ei), whatever other ranged gear you can scrounge up, crossbow, Sara items, hammer, fire staff, nature runes, a lot of money (obtained during the step, spent during the step).",
                 "skills_quests_met": "yes",
-                "total_time": "25d4h"
-              },
-              "additionalContent": [
-                [
-                  {
-                    "text": "Read this step in its entirety carefully. This step contains the Hallowed Sepulchre grind to level 82 agility.\n",
-                    "formatting": {
-                      "bold": true
-                    }
-                  }
-                ]
-              ]
+                "total_time": "24d22h"
+              }
             },
             {
               "content": [
@@ -19197,7 +20016,7 @@
                   }
                 },
                 {
-                  "text": ") your mithril from MLM. Smelt your gold ore from MLM. Use the UIM gold method (",
+                  "text": ") your mithril from MLM. Smelt your lead ore into bars. Smelt your gold ore from MLM. Use the UIM gold method (",
                   "formatting": {}
                 },
                 {
@@ -19209,11 +20028,8 @@
                   }
                 },
                 {
-                  "text": ") to train your smithing to level 70, getting permission from the foreman to use the blast furnace for free at level 60. Turn all your mithril bars into platebodies (Varrock west anvils, make 10 bars into 150 nails, make a mithril 2h sword for Devious Minds and ~5 bars into grapples along the way), then alch them (similar to before). Hybrid ore uim smelt your addy (buy coal as needed) into bars. Use UIM gold to train your smithing to (15,000 xp away from) level 74. Make sure to equip your ring of charos (a) until level 60 for reduced foreman costs.  Start and complete Defender of Varrock (there’s a free 5k xp lamp after the quest at Historian Minas in the Varrock Museum, put it on slayer if you aren’t level 58 yet and herblore otherwise). Make 4950 adamant nails (make sure to save an adamantite bar) with your bars at Varrock west anvils.\n",
+                  "text": ") to train your smithing to level 70, getting permission from the foreman to use the blast furnace for free at level 60. Go to Varrock west anvils, make 10 bars into 150 nails, make a mithril 2h sword for Devious Minds and ~5 bars into grapples. Turn the rest into mithril platebode and alch them (similar to before). Hybrid ore uim smelt your addy (buy coal as needed) into bars. Use UIM gold to train your smithing to (15,000 xp away from) level 74. Make sure to equip your ring of charos (a) until level 60 for reduced foreman costs.  Start and complete Defender of Varrock (there’s a free 5k xp lamp after the quest at Historian Minas in the Varrock Museum, put it on slayer if you aren’t level 58 yet and herblore otherwise). Make 4950 adamant nails (make sure to save an adamantite bar) with your bars at Varrock west anvils.\n",
                   "formatting": {}
-                },
-                {
-                  "text": "Skills/quests met?:"
                 }
               ],
               "nestedContent": [
@@ -19246,18 +20062,25 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "2.5m gp",
+                "gp_stack": "900k gp",
                 "items_needed": "tbd",
-                "total_time": "25d22h"
+                "skills_quests_met": "yes",
+                "total_time": "25d16h"
               }
             },
             {
               "content": [
                 {
-                  "text": "Note: if you are not planning to max you can reduce this step, although the lack of prayer potions might prove to be an issue for slayer later. You will also need to obtain more planks and train construction at your own convenience if you do not go to at least level 96 agility during this step. That being said, 98 agility at Sepulchre is a loooong grind, so give serious consideration to reducing/splitting it. ",
+                  "text": "Note: if you are not planning to max you can reduce this step, although the lack of prayer potions might prove to be an issue for slayer later. You will also need to obtain more planks and train construction at your own convenience if you do not go to at least level 96 agility during this step. That being said, 98 agility at Sepulchre is a loooong grind, so give serious consideration to reducing/splitting it.",
                   "formatting": {
                     "italic": true,
                     "underline": true
+                  }
+                },
+                {
+                  "text": " ",
+                  "formatting": {
+                    "italic": true
                   }
                 },
                 {
@@ -19464,7 +20287,7 @@
                   "level": 1,
                   "content": [
                     {
-                      "text": "After Misc is up and running, buy arrow shafts and headless arrows (in smaller chunks) to get to a total of 1 million headless arrows through fletchpalchre.\n",
+                      "text": "After Misc is up and running, buy arrow shafts(/cut them from maples) and buy feathers (in smaller chunks) to get to a total of 1 million headless arrows through fletchpalchre.\n",
                       "formatting": {}
                     }
                   ]
@@ -19763,10 +20586,10 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "22.5m gp",
+                "gp_stack": "21.4m gp",
                 "items_needed": "crossbow, Sara items, teak planks, addy nails, hammer, fire staff, nature runes, a lot of money (obtained during the step, spent during the step).",
                 "skills_quests_met": "yes",
-                "total_time": "34d22h"
+                "total_time": "34d16h"
               }
             }
           ],
@@ -19868,10 +20691,14 @@
                   "level": 1,
                   "content": [
                     {
-                      "text": "The total item requirements for this are: 1 marble block, 1 magic stone, 1 gold leaf, 1 spirit sapling, 19 oak planks, 17 teak planks, 8 mahogany planks.\n",
+                      "text": "The total item requirements for this are: 1 marble block, 1 magic stone, 1 gold leaf, 1 spirit sapling, 19 oak planks, 17 teak planks, 8 mahogany planks.",
                       "formatting": {
                         "bold": true
                       }
+                    },
+                    {
+                      "text": " You may need to convert a few more logs into planks to get all these item requirements.\n",
+                      "formatting": {}
                     }
                   ]
                 },
@@ -19920,10 +20747,10 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "20.7m gp",
+                "gp_stack": "19.7m gp",
                 "items_needed": "crystal saw, hammer, items mentioned above",
                 "skills_quests_met": "yes",
-                "total_time": "34d23h"
+                "total_time": "34d17h"
               }
             },
             {
@@ -19954,10 +20781,10 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "20.7m gp",
+                "gp_stack": "19.7m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
-                "total_time": "35d1h"
+                "total_time": "34d17h"
               }
             },
             {
@@ -19969,16 +20796,16 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "20.7m gp",
+                "gp_stack": "19.7m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
-                "total_time": "35d2h"
+                "total_time": "34d20h"
               }
             },
             {
               "content": [
                 {
-                  "text": "Do Zogre Flesh Eaters (on Arceuus spellbook, use dueling rings and fairy rings for speeding up the quest), killing Zogres along the way for Rag and Bone Man II. Make sure to unlock Uglug’s Stuffsies. Swap to the normal spellbook for the Slash Bash fight to use Crumble Undead. Make a composite ogre bow (comp ogre bow) and 150 mithril brutal nails, kill 125 chompies for the diary. Speak with Rantz to collect a (handful of) Chompy bird hat(s).\n",
+                  "text": "Make a composite ogre bow (comp ogre bow) and 150 mithril brutal arrows, kill 125 chompies for the diary. Speak with Rantz to collect a (handful of) Chompy bird hat(s).\n",
                   "formatting": {}
                 }
               ],
@@ -19994,10 +20821,69 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "20.7m gp",
+                "gp_stack": "19.7m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
-                "total_time": "35d6h"
+                "total_time": "35d0h"
+              }
+            },
+            {
+              "content": [
+                {
+                  "text": "Make 20 bolts of canvas. Build the mahogany mast and canvas sails on your skiff using the hemp you farmed, build the mithril helm on your skiff (not sloop) and the inoculation station on your sloop. Do the Jubbly Jive barracuda trial and complete up to the shark rank. Build a wind catcher on both your skiff and your sloop, then return to the Jubbly Jive and keep training sailing to level 67 sailing using the following method for Marlin rank: ",
+                  "formatting": {}
+                },
+                {
+                  "text": "https://www.youtube.com/watch?v=1d2LIrd7_rM",
+                  "formatting": {
+                    "underline": true,
+                    "color": {
+                      "r": 0.06666667,
+                      "g": 0.33333334,
+                      "b": 0.8
+                    },
+                    "url": "https://www.youtube.com/watch?v=1d2LIrd7_rM",
+                    "isLink": true
+                  }
+                },
+                {
+                  "text": ". At your convenience, return to the Ardent Ocean meteorologists for those charting tasks. Optional but not recommended: if you prefer alternative training methods you can choose between Rellekka courier tasks (",
+                  "formatting": {}
+                },
+                {
+                  "text": "Sailing training - OSRS Wiki",
+                  "formatting": {
+                    "underline": true,
+                    "color": {
+                      "r": 0.06666667,
+                      "g": 0.33333334,
+                      "b": 0.8
+                    },
+                    "url": "https://oldschool.runescape.wiki/w/Sailing_training#Levels_62-70:_Rellekka",
+                    "isLink": true
+                  }
+                },
+                {
+                  "text": ") or salvaging over Jubbly Jive.\n",
+                  "formatting": {}
+                }
+              ],
+              "nestedContent": [
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "You now have access to Deepfin Point, which contains the best method for ironmenn to obtain blue dragon scales (using the general store in the mine), even beating out harvesting potato cactus.\n",
+                      "formatting": {}
+                    }
+                  ]
+                }
+              ],
+              "metadata": {
+                "gp_stack": "19.7m gp",
+                "items_needed": "tbd",
+                "skills_quests_met": "yes",
+                "total_time": "35d5h"
               }
             },
             {
@@ -20009,7 +20895,7 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "20.7m gp",
+                "gp_stack": "19.7m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "35d6h"
@@ -20024,7 +20910,7 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "20.7m gp",
+                "gp_stack": "19.7m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "35d6h"
@@ -20039,7 +20925,7 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "20.7m gp",
+                "gp_stack": "19.7m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "35d6h"
@@ -20062,33 +20948,10 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "20.6m gp",
+                "gp_stack": "19.7m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "35d6h"
-              }
-            },
-            {
-              "content": [
-                {
-                  "text": "Complete the Kourend Medium diary and cash in the reward (lamp on herblore).",
-                  "formatting": {}
-                },
-                {
-                  "text": "\n",
-                  "formatting": {
-                    "italic": true
-                  }
-                },
-                {
-                  "text": "Skills/quests met?:"
-                }
-              ],
-              "nestedContent": [],
-              "metadata": {
-                "gp_stack": "20.6m",
-                "items_needed": "tbd",
-                "total_time": "35d7h"
               }
             },
             {
@@ -20148,7 +21011,7 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "20.6m gp",
+                "gp_stack": "19.7m gp",
                 "items_needed": "melee gear, prayer potions, mirror shield, law runes, soul runes, dramen staff, fishing explosives",
                 "skills_quests_met": "yes",
                 "total_time": "35d7h"
@@ -20189,7 +21052,7 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "20.6m gp",
+                "gp_stack": "19.7m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "35d7h"
@@ -20225,7 +21088,7 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "20.6m gp",
+                "gp_stack": "19.7m gp",
                 "items_needed": "2 vials of water, 2 tarromins, leather gloves, rune axe, cheese potatoes, Iban staff, death runes, fire runes, water runes, air staff, law runes, dueling ring, prayer pots, energy pots",
                 "skills_quests_met": "yes",
                 "total_time": "35d8h"
@@ -20281,7 +21144,7 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "20.6m gp",
+                "gp_stack": "19.7m gp",
                 "items_needed": "Ectophial, melee gear, cheese potatoes, prayer pots, stat-boosting pots, energy pots, fishbowl helmet + diving apparatus, 18 planks, 10 bear fur, hammer, holy symbol, ring of charos(a), bowl, 15 chaos runes, law runes, fire runes, air staff, rune axe, fremennik boots, watermelon seeds, ultracompost, rake, seed dibber",
                 "skills_quests_met": "yes",
                 "total_time": "35d10h"
@@ -20528,7 +21391,7 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "20.6m gp",
+                "gp_stack": "19.7m gp",
                 "items_needed": "follow the wiki; the entire quest line is basically linear (no choice)",
                 "skills_quests_met": "yes",
                 "total_time": "35d18h"
@@ -21384,7 +22247,7 @@
               }
             },
             {
-              "text": "94",
+              "text": "94\n",
               "formatting": {
                 "color": {
                   "r": 0,
@@ -21392,16 +22255,20 @@
                   "b": 0.2
                 }
               }
-            },
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
             {
-              "text": "\n",
+              "text": "Sailing: 67\n",
               "formatting": {
                 "color": {
                   "r": 0,
                   "g": 0.6627451,
                   "b": 0.2
-                },
-                "fontSize": 12
+                }
               }
             }
           ],
@@ -21476,7 +22343,7 @@
               "formatting": {}
             },
             {
-              "text": "20251019Chapter1",
+              "text": "20260525Chapter1",
               "url": "https://docs.google.com/document/d/1gCez5XG5FA1kmmBYydur3RaI_cr-dYNJlnigRrByEX8/edit",
               "isLink": true,
               "formatting": {
@@ -21485,7 +22352,9 @@
             },
             {
               "text": "\n",
-              "formatting": {}
+              "formatting": {
+                "bold": true
+              }
             }
           ],
           "type": "chapter_footnote"
@@ -21497,7 +22366,7 @@
               "formatting": {}
             },
             {
-              "text": "20251019Chapter2",
+              "text": "20260525Chapter2",
               "url": "https://docs.google.com/document/d/1YQiZ6curEYPpgm3DtjZcWHPoEEkGpYdXZ-I0gCM5p10/edit",
               "isLink": true,
               "formatting": {
@@ -21518,7 +22387,7 @@
               "formatting": {}
             },
             {
-              "text": "20251019Chapter3",
+              "text": "20260525Chapter3",
               "url": "https://docs.google.com/document/d/1O1VeAkwS6VAzGVy0GT205GqiNaOAbw17H5uyuMwz39o/edit?usp=sharing",
               "isLink": true,
               "formatting": {
@@ -21539,7 +22408,7 @@
               "formatting": {}
             },
             {
-              "text": "20251019DetailedStepsGuide",
+              "text": "20260525DetailedStepsGuide",
               "url": "https://docs.google.com/spreadsheets/d/1XZ-3Kja7_QS4Rxj4mJXeATXHBP03lrdUSt46gO3pWHk/edit#gid=1506136399",
               "isLink": true,
               "formatting": {
@@ -21570,6 +22439,136 @@
                 },
                 "url": "https://drive.google.com/drive/folders/1mqirlAU0Pk5OGI5V8NN9BhHKIeGwG1Ea",
                 "isLink": true
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
+                "fontFamily": "Arial"
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "Tool for comparing Landlubber to current: ",
+              "formatting": {
+                "fontFamily": "Arial"
+              }
+            },
+            {
+              "text": "https://pobblesbe.github.io/bruhsailer-transition-tool/",
+              "formatting": {
+                "underline": true,
+                "color": {
+                  "r": 0.06666667,
+                  "g": 0.33333334,
+                  "b": 0.8
+                },
+                "fontFamily": "Arial",
+                "url": "https://pobblesbe.github.io/bruhsailer-transition-tool/",
+                "isLink": true
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {}
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "\n",
+              "formatting": {}
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "Landlubber version (pre sailing):\n",
+              "formatting": {
+                "italic": true,
+                "fontFamily": "Arial"
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20251019Chapter1 - Landlubber",
+              "url": "https://docs.google.com/document/d/1xZ03yH6BFzXVS5Q17ghYB6oiITD6xgSDgHy_Ar5PakU/edit?usp=drive_link",
+              "isLink": true,
+              "formatting": {
+                "underline": true,
+                "fontFamily": "Arial"
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
+                "fontFamily": "Arial"
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20251019Chapter2 - Landlubber",
+              "url": "https://docs.google.com/document/d/1ppJIpSY88DJMIcn0BBUBODe7wOrQFrKmjeNv0OvKVMs/edit?usp=sharing",
+              "isLink": true,
+              "formatting": {
+                "underline": true,
+                "fontFamily": "Arial"
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
+                "fontFamily": "Arial"
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20251019Chapter3 - Landlubber",
+              "url": "https://docs.google.com/document/d/1yPlKxtX96f4eYsXaga57Hl4EW7M8WMscVKaSfDoGGaA/edit?usp=sharing",
+              "isLink": true,
+              "formatting": {
+                "underline": true,
+                "fontFamily": "Arial"
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
+                "fontFamily": "Arial"
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20251019DetailedStepsGuide - Landlubber",
+              "url": "https://docs.google.com/spreadsheets/d/1BspIE07aWfP0Z2o2y3L5Qi9P27ctinDA9igNOkIhK3o/edit?usp=sharing",
+              "isLink": true,
+              "formatting": {
+                "underline": true,
+                "fontFamily": "Arial"
               }
             },
             {
@@ -21835,7 +22834,125 @@
             },
             {
               "text": "\n",
+              "formatting": {
+                "italic": true,
+                "fontSize": 11,
+                "fontFamily": "Arial"
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20260308BRUHsailerChangelog.txt",
+              "formatting": {
+                "underline": true,
+                "color": {
+                  "r": 0.06666667,
+                  "g": 0.33333334,
+                  "b": 0.8
+                },
+                "fontFamily": "Arial",
+                "url": "https://drive.google.com/file/d/1sj648WdEj8dXS-kJm5xyKZFxa-APM5CX/view?usp=sharing",
+                "isLink": true
+              }
+            },
+            {
+              "text": "\n",
               "formatting": {}
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20260310: Moved Zogre Flesh Eaters for early inoculation station, finished Shrouded Ocean",
+              "formatting": {
+                "italic": true
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
+                "fontFamily": "Arial"
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20260327BRUHsailerChangelog.txt",
+              "formatting": {
+                "underline": true,
+                "color": {
+                  "r": 0.06666667,
+                  "g": 0.33333334,
+                  "b": 0.8
+                },
+                "fontFamily": "Arial",
+                "url": "https://drive.google.com/file/d/16LdgtZVcg81vRr2-RZ-0J9tQW8kJG-sh/view?usp=sharing",
+                "isLink": true
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
+                "italic": true
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20260410BRUHsailerChangelog.txt",
+              "formatting": {
+                "underline": true,
+                "color": {
+                  "r": 0.06666667,
+                  "g": 0.33333334,
+                  "b": 0.8
+                },
+                "url": "https://drive.google.com/file/d/1Vgsc6cbQkVZq0zK_1N8kiITWsTdirKJl/view?usp=sharing",
+                "isLink": true
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
+                "fontFamily": "Arial"
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20260525BRUHsailerChangelog.txt",
+              "formatting": {
+                "underline": true,
+                "color": {
+                  "r": 0.06666667,
+                  "g": 0.33333334,
+                  "b": 0.8
+                },
+                "fontFamily": "Arial",
+                "url": "https://drive.google.com/file/d/1heQH8NuLiDIc7S9MwRoW-Y7uoRlgm-5-/view?usp=sharing",
+                "isLink": true
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
+                "italic": true
+              }
             }
           ],
           "type": "chapter_footnote"
@@ -21878,7 +22995,7 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "21m",
+                "gp_stack": "20m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "tbd"
@@ -21893,7 +23010,7 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "21m",
+                "gp_stack": "20m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "tbd"
@@ -21902,7 +23019,7 @@
             {
               "content": [
                 {
-                  "text": "Using your mahogany logs from Miscellania, train construction to level 75 (do not go higher for now). Build the following in your POH, boosting when necessary:\n",
+                  "text": "Using your mahogany logs from Miscellania, train construction to level 75 (do not go higher for now and keep 20 mahogany planks for sailing). Build the following in your POH, boosting when necessary:\n",
                   "formatting": {}
                 }
               ],
@@ -21974,7 +23091,7 @@
                   "level": 1,
                   "content": [
                     {
-                      "text": "The total item requirements for this are: 1 Arceuus signet, 1 bolt of cloth, 1 steel bar, 3 games necklaces(8), 3 rings of dueling(8), 8 marble blocks (for the gilded portal nexus), 3 gold leaves (of which two are for the gilded portal nexus), 1 magic stone, 15 limestone bricks, 5 buckets of water, 6000 soul runes, 5000 blood runes, 1000 body runes, 10 stamina potions(4), 10 prayer potions(4), 11 mahogany planks.\n",
+                      "text": "The total item requirements for this are: 1 Arceuus signet, 1 bolt of cloth, 1 steel bar, 3 games necklaces(8), 3 rings of dueling(8), 8 marble blocks (for the gilded portal nexus), 3 gold leaves (of which two are for the gilded portal nexus), 1 magic stone (but 2 if you want to build the bank chest on Sunbleak Island), 15 limestone bricks, 5 buckets of water, 6000 soul runes, 5000 blood runes, 1000 body runes, 10 stamina potions(4), 10 prayer potions(4), 9 mahogany planks.\n",
                       "formatting": {
                         "bold": true
                       }
@@ -21998,7 +23115,7 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "16m",
+                "gp_stack": "15m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "tbd"
@@ -22053,7 +23170,7 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "16m",
+                "gp_stack": "15m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "tbd"
@@ -22104,7 +23221,7 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "16m",
+                "gp_stack": "15m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "tbd"
@@ -22178,7 +23295,7 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "16m",
+                "gp_stack": "15m gp",
                 "items_needed": "Superantipoison potions, any food",
                 "skills_quests_met": "yes",
                 "total_time": "tbd"
@@ -22187,7 +23304,7 @@
             {
               "content": [
                 {
-                  "text": "Train slayer to get to 100cb. Your target stats are 78 Attack, 85 Strength, 75(+) Defence and 72(+) prayer, which should probably give you 78(+)Hitpoints and ~75 Slayer around the time you hit 100cb.\n",
+                  "text": "Collect buckets of sand and giant seaweed to train your crafting level to 80 (or 75, boosting after) using SGM and arteglass. Make an amulet of glory. Train slayer to get to 100cb. Your target stats are 78 Attack, 85 Strength, 75(+) Defence and 72(+) prayer, which should probably give you 78(+)Hitpoints and ~75 Slayer around the time you hit 100cb.\n",
                   "formatting": {}
                 }
               ],
@@ -22236,7 +23353,7 @@
                       "formatting": {}
                     },
                     {
-                      "text": "20251019SlayerGuide",
+                      "text": "20260525SlayerGuide",
                       "url": "https://docs.google.com/document/d/1kBMW2uRI8b4NBcYn9PmsedTnZ3yW7fuGwdzsRQSCNkk/edit?usp=sharing",
                       "isLink": true,
                       "formatting": {
@@ -22253,7 +23370,7 @@
                   "level": 1,
                   "content": [
                     {
-                      "text": "If you (somehow) do not have runes for thralls or barrage, buy them.\n",
+                      "text": "If you (somehow) do not have runes for thralls or barrage, buy them. If you intend to do ship combat (recommended), buy 5k water runes and 1k law runes (if you happen to already have these, just use those instead) as well.\n",
                       "formatting": {}
                     }
                   ]
@@ -22408,7 +23525,7 @@
                       }
                     },
                     {
-                      "text": ". Do the Kourend & Kebos Hard diary (lamp on RC), then cook the karambwans at your convenience (1t cooking at the Hosidius range is best, cooking gauntlets do not work on karambwans).\n",
+                      "text": ". Do the Kourend & Kebos Hard diary (lamp on herblore), then cook the karambwans at your convenience (1t cooking at the Hosidius range is best, cooking gauntlets do not work on karambwans).\n",
                       "formatting": {}
                     }
                   ]
@@ -22510,7 +23627,7 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "13m",
+                "gp_stack": "12m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "tbd"
@@ -22519,7 +23636,7 @@
             {
               "content": [
                 {
-                  "text": "Optional but recommended: collect buckets of sand and giant seaweed to train your crafting level to 80 (or 75, boosting after) using SGM and arteglass. Make an amulet of glory. Regardless of whether you include the above: buy broad arrowhead packs with most of your money (leave ~500k in reserve, buy the broad arrowtip packs at any slayer master, if you are opening fast enough the stock will slowly deplete. Hop worlds if the stock ever hits 700 or lower). Do Pest Control, veteran i.e. 100+ cb boat, for enough points for full elite void range (other two helmets optional) while fletching – 1250 points for just ranging, 1650 points for a full set, fletching during the games and only contributing as much as necessary to get points. You can optionally get the other two helmets as well, or ignore them(/consider getting them later).",
+                  "text": "Buy broad arrowhead packs with most of your money, leaving 1250k in reserve. Buy the broad arrowtip packs at any slayer master, if you are opening fast enough the stock will slowly deplete. Hop worlds if the stock ever hits 700 or lower. Do Pest Control, veteran i.e. 100+ cb boat, for enough points for full elite void range (other two helmets optional) while fletching – 1250 points for just ranging, 1650 points for a full set, fletching during the games and only contributing as much as necessary to get points. You can optionally get the other two helmets as well, or ignore them(/consider getting them later).",
                   "formatting": {}
                 },
                 {
@@ -22529,7 +23646,7 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "500k",
+                "gp_stack": "1250k gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "tbd"
@@ -22554,112 +23671,8 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "500k",
+                "gp_stack": "1250k gp",
                 "items_needed": "tons and tons of items (these are linear quests so just follow the wiki)",
-                "skills_quests_met": "yes",
-                "total_time": "tbd"
-              }
-            },
-            {
-              "content": [
-                {
-                  "text": "Optional but recommended: with the Karamja Hard diary completed, 3t gem mine to level 97 mining (",
-                  "formatting": {}
-                },
-                {
-                  "text": "gems route",
-                  "url": "https://www.youtube.com/watch?v=JCD8mwJVygI",
-                  "isLink": true,
-                  "formatting": {
-                    "underline": true,
-                    "fontFamily": "Arial"
-                  }
-                },
-                {
-                  "text": "), banking the uncut gems using the deposit box. This requires a charged amulet of glory. With multiskill cutting the gems (see below) this is more efficient than 3t4g. This requires a charged amulet of glory! If you make one here you won’t have to make one next step. ",
-                  "formatting": {
-                    "fontFamily": "Arial"
-                  }
-                },
-                {
-                  "text": "You may skip this step if you don’t value multiskilling or efficiency enough to take such a long detour/don’t feel like it.",
-                  "formatting": {
-                    "italic": true,
-                    "fontFamily": "Arial"
-                  }
-                },
-                {
-                  "text": "\n",
-                  "formatting": {
-                    "italic": true
-                  }
-                }
-              ],
-              "nestedContent": [],
-              "metadata": {
-                "gp_stack": "500k",
-                "items_needed": "tbd",
-                "skills_quests_met": "yes",
-                "total_time": "tbd"
-              }
-            },
-            {
-              "content": [
-                {
-                  "text": "Go to Guardians of the Rift, participate in the minigame with the multiskilling method until you are completely out of uncut gems.\n",
-                  "formatting": {}
-                }
-              ],
-              "nestedContent": [
-                {
-                  "level": 1,
-                  "content": [
-                    {
-                      "text": "Guardians of the Rift - multiskilling",
-                      "url": "https://youtu.be/vAKese2xurs?list=PL1YmaQEbqW1jX9evljFu_CaJ-w-fueXUs",
-                      "isLink": true,
-                      "formatting": {
-                        "underline": true
-                      }
-                    },
-                    {
-                      "text": " - this video shows a simple example of multiskill Guardians of the Rift - you still make combination runes, but focus on skilling rather than participating throughout most of the game (in fact, you only enter the west essence mine when it opens and ignore all other opportunities to collect essence). ",
-                      "formatting": {}
-                    },
-                    {
-                      "text": "The best way",
-                      "formatting": {
-                        "bold": true
-                      }
-                    },
-                    {
-                      "text": " to multiskill is by carrying a gem bag full with uncut gems (60 sapphires, emeralds, rubies and diamonds) into the minigame, taking them out of the gem sack, cutting them and depositing them at the Deposit Pool (which acts as a regular deposit box!) one inventory at a time. The point and xp rate will be lower than active GotR, but the crafting xp makes it more efficient.\n",
-                      "formatting": {}
-                    }
-                  ]
-                },
-                {
-                  "level": 1,
-                  "content": [
-                    {
-                      "text": "An important strategy to increase your points per game (and per hour) at guardians of the rift is ‘empty cell running’. When out of essence, grab a cell from the table and enter an altar (higher tier is better) to charge the cell. Then deposit it for points, ideally on a golem but on a barrier is also fine. You can combine this with multiskilling for efficiency.\n",
-                      "formatting": {}
-                    }
-                  ]
-                },
-                {
-                  "level": 1,
-                  "content": [
-                    {
-                      "text": "Make an amulet of glory when you have the crafting level (75+5) to make one.\n",
-                      "formatting": {}
-                    }
-                  ]
-                }
-              ],
-              "metadata": {
-                "gp_stack": "500k",
-                "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "tbd"
               }
@@ -22691,7 +23704,7 @@
                   }
                 },
                 {
-                  "text": ". If you want to catch red chinchompas but the Varlamore spot is too competitive, e.g. with bots, the second best option is catching them northeast of Prifddinas. Throw the chins in the cave to get to 70 ranging, complete the Western Provinces Hard Diary (this involves getting one Zulrah kill), upgrade your void to Elite, (optionally: grab an offtask fire cape at some point along the way), return and throw the chins to get to level 92 ranging.\n",
+                  "text": ". If you want to catch red chinchompas but the Varlamore spot is too competitive, e.g. with bots, the second best option is catching them northeast of Prifddinas. Throw the chins in the cave to get to 70 ranging, complete the Western Provinces Hard Diary (this involves getting one Zulrah kill), upgrade your void to Elite, (optionally: grab an offtask fire cape at some point along the way), buy a crystal halberd, return and throw the chins to get to level 92 ranging.\n",
                   "formatting": {}
                 }
               ],
@@ -22969,8 +23982,442 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "500k",
+                "gp_stack": "500k gp",
                 "items_needed": "red/black chins, elite void ranged, ranging pots, glory, shayzien boots 5, red dragonhide shield optional.",
+                "skills_quests_met": "yes",
+                "total_time": "tbd"
+              }
+            },
+            {
+              "content": [
+                {
+                  "text": "The following steps 11-15 are best combined, to break up the CG grind with skilling activities. Read ahead to combine these steps at your convenience. ",
+                  "formatting": {
+                    "bold": true
+                  }
+                },
+                {
+                  "text": "Optional but recommended: with the Karamja Hard diary completed, 3t gem mine to level 97 mining (",
+                  "formatting": {}
+                },
+                {
+                  "text": "gems route",
+                  "url": "https://www.youtube.com/watch?v=JCD8mwJVygI",
+                  "isLink": true,
+                  "formatting": {
+                    "underline": true,
+                    "fontFamily": "Arial"
+                  }
+                },
+                {
+                  "text": "), banking the uncut gems using the deposit box. This requires a charged amulet of glory. With multiskill cutting the gems (see below) this is more efficient than 3t4g. This requires a charged amulet of glory! If you make one here you won’t have to make one next step. ",
+                  "formatting": {
+                    "fontFamily": "Arial"
+                  }
+                },
+                {
+                  "text": "You may skip this step if you don’t value multiskilling or efficiency enough to take such a long detour/don’t feel like it.",
+                  "formatting": {
+                    "italic": true,
+                    "fontFamily": "Arial"
+                  }
+                },
+                {
+                  "text": "\n",
+                  "formatting": {
+                    "italic": true
+                  }
+                }
+              ],
+              "nestedContent": [],
+              "metadata": {
+                "gp_stack": "500k gp",
+                "items_needed": "tbd",
+                "skills_quests_met": "yes",
+                "total_time": "tbd"
+              }
+            },
+            {
+              "content": [
+                {
+                  "text": "Make sure you have at least 75 mining (if not, do some gem mining first). Take a charter ship to The Great Conch (Summer Shore) start The Red Reef and complete the steps until you are sent to the Red Rock. Charter to Deepfin Point, mine 24 nickel ore. Do blast mining (as before) to obtain 551 addy ore - you may have to convert some of the gems into alchs (cut sapphires, emeralds and even rubies are fine, or make ruby and diamond bracelets) for dynamite. Make sure you get at least 15 runite ore along the way. Smelt all the addy into bars, all the nickel into cupronickel bars, then convert 71 addy bars into 1065 addy nails. Teleport to The Great Conch (fairy ring CJQ) and chop and bank up to 505 camphor logs. The fastest method is using a log basket and teleporting out to a bank, then using the fairy ring to get back. If you have (or plan to get) sawmill vouchers you can reduce the number of logs needed by 1 for each voucher for up to 236 vouchers (and 269 logs), saving 2,500 gp each (590k gp total). Make 473 camphor planks. Build the following ship upgrades:\n",
+                  "formatting": {}
+                }
+              ],
+              "nestedContent": [
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "Camphor cargo hold (sloop)\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "Adamant keel (skiff + sloop)\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "Camphor hull (skiff + sloop)\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "Camphor mast and canvas sails (skiff + sloop) - this requires a boost to build\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "Optional but recommended ",
+                      "formatting": {}
+                    },
+                    {
+                      "text": "(see next step)",
+                      "formatting": {
+                        "bold": true
+                      }
+                    },
+                    {
+                      "text": ": adamant cannon x2 (sloop) - this requires a boost to build. Note that your salvaging hooks are in the way - you can just discard the mithril ones, but for higher tiers you’d use ",
+                      "formatting": {}
+                    },
+                    {
+                      "text": "Facility bottle - OSRS Wiki",
+                      "formatting": {
+                        "underline": true,
+                        "color": {
+                          "r": 0.06666667,
+                          "g": 0.33333334,
+                          "b": 0.8
+                        },
+                        "url": "https://oldschool.runescape.wiki/w/Facility_bottle",
+                        "isLink": true
+                      }
+                    },
+                    {
+                      "text": " at 75k gp each to swap your facilities around. Also build a ballistic attractor.",
+                      "formatting": {}
+                    },
+                    {
+                      "text": "\n",
+                      "formatting": {}
+                    }
+                  ]
+                }
+              ],
+              "metadata": {
+                "gp_stack": "35k gp",
+                "items_needed": "tbd",
+                "skills_quests_met": "yes",
+                "total_time": "tbd"
+              }
+            },
+            {
+              "content": [
+                {
+                  "text": "Recruit Cabin Boy Jenkins (and Adventurer Ada while you’re at it) so you can get most xp out of multiskilling while charting. Use your skiff to chart the Sunset Ocean and Western Ocean in full, the lower level seas in the Shrouded Ocean along with all Miscellaneous charts in the ",
+                  "formatting": {}
+                },
+                {
+                  "text": "same areas. Buy ",
+                  "formatting": {}
+                },
+                {
+                  "text": "5k",
+                  "formatting": {}
+                },
+                {
+                  "text": " mithril c",
+                  "formatting": {}
+                },
+                {
+                  "text": "annonballs at Port Roberts. Collect your charting xp bonuses from Chartin’ Charles McAtless. Optional and recommended, if you care for the rewards below from ship combat: also buy 25 Perildance bitters. Recruit Oarswoman Olga and Jittery Jim (boost to recruit him) and assign them to your sloop.\n",
+                  "formatting": {}
+                }
+              ],
+              "nestedContent": [
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "First do part of the Shrouded Ocean ",
+                      "formatting": {}
+                    },
+                    {
+                      "text": "Shrouded Ocean, partial.png",
+                      "url": "https://drive.google.com/file/d/1nhfMHSenwO-IiB_Fg029qHTIoO84fi3H/view?usp=sharing",
+                      "isLink": true,
+                      "formatting": {
+                        "underline": true
+                      }
+                    },
+                    {
+                      "text": ", starting at Corsair Cove (teleport there and recover your boat). While in the Simian sea, head to Red Rock and continue the Red Reef quest (collect the Sailor’s Marker on the dock too!) until you’ve completed all steps there except reporting back to Floopa. Use protect from ranged in the ship combat - you can just use your bowfa to shoot the pirates instead of using your cannons, your choice. Make sure to visit the Isle of Bones to collect the small key (",
+                      "formatting": {}
+                    },
+                    {
+                      "text": "Lost schematics - OSRS Wiki",
+                      "formatting": {
+                        "underline": true,
+                        "color": {
+                          "r": 0.06666667,
+                          "g": 0.33333334,
+                          "b": 0.8
+                        },
+                        "url": "https://oldschool.runescape.wiki/w/Lost_schematics",
+                        "isLink": true
+                      }
+                    },
+                    {
+                      "text": ") and investigate the cauldron to get a medallion fragment, include the additional south step of visiting the Charred Island for another key, dock at Tear of the Soul for a third key, and later still collect the gale catcher schematic on Angler’s retreat.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "Then the Western Ocean, continuing where the previous part ended. ",
+                      "formatting": {}
+                    },
+                    {
+                      "text": "Western Ocean, part 1.png",
+                      "url": "https://drive.google.com/file/d/1CNcutFW-IcyESB94Fn6SeMK8vzbscE5r/view?usp=sharing",
+                      "isLink": true,
+                      "formatting": {
+                        "underline": true
+                      }
+                    },
+                    {
+                      "text": ". Warning: the crates in the Backwater will poison, disease and venom you (two different crates total) so bring an antipoison. Dock on Minotaur’s Rest to collect the small key, dock at Vatrachos Island and give the raccoon a berry (",
+                      "formatting": {}
+                    },
+                    {
+                      "text": "Raccoon (Vatrachos Island) - OSRS Wiki",
+                      "formatting": {
+                        "underline": true,
+                        "color": {
+                          "r": 0.06666667,
+                          "g": 0.33333334,
+                          "b": 0.8
+                        },
+                        "url": "https://oldschool.runescape.wiki/w/Raccoon_(Vatrachos_Island)",
+                        "isLink": true
+                      }
+                    },
+                    {
+                      "text": ") to get a medallion fragment, dock at Wintumber Island to chart the crab monument and collect a medallion piece, then later dock at the Crown Jewel to collect the rosewood cargo hold schematic. The bottle of portal nexus perry will teleport you to the Abyss so drink it last.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "Then chart the Sunset Ocean, starting from Aldarin twice: first with your raft (pink), then with your skiff (red). ",
+                      "formatting": {}
+                    },
+                    {
+                      "text": "Sunset Ocean.png",
+                      "url": "https://drive.google.com/file/d/1-wpT9W-att5BwD8nUaeJwvUmBrYrby9G/view?usp=sharing",
+                      "isLink": true,
+                      "formatting": {
+                        "underline": true
+                      }
+                    },
+                    {
+                      "text": " It is possible to only use the skiff, if you prefer, but the raft is easier. Dock at the Laguna Aurorae to collect a small key and at the Shimmering Atoll to obtain the rosewood hull schematic and chop a teak tree to obtain a medallion fragment.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "Then more Western Ocean, starting at Land’s End",
+                      "formatting": {}
+                    },
+                    {
+                      "text": "Western Ocean, part 2.png",
+                      "url": "https://drive.google.com/file/d/1Nk25uRTcRd3KBTXUsxZKxL0cT5Il8GLp/view?usp=sharing",
+                      "isLink": true,
+                      "formatting": {
+                        "underline": true
+                      }
+                    },
+                    {
+                      "text": ". The bottle of sea shandy 2 will teleport you and your ship to Port Sarim, so dock at Port Piscarilius before drinking it and charter back (and recover your ship).\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "Then more Western Ocean, continuing where the previous part ended. ",
+                      "formatting": {}
+                    },
+                    {
+                      "text": "Western Ocean, part 3.png",
+                      "url": "https://drive.google.com/file/d/1OQhVEegf7bwle9iKF27cLiWzTi9gwIDK/view?usp=sharing",
+                      "isLink": true,
+                      "formatting": {
+                        "underline": true
+                      }
+                    },
+                    {
+                      "text": ". Watch out, the bottle of banker’s draught (south Port Poscarilius) will bank your items - drink this last.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "Then more Western Ocean, continuing where the previous part ended. ",
+                      "formatting": {}
+                    },
+                    {
+                      "text": "Western Ocean, part 4.png",
+                      "url": "https://drive.google.com/file/d/1SB9JlvSfYBRZn0aNtYHaC2_RmQ65JNCA/view?usp=sharing",
+                      "isLink": true,
+                      "formatting": {
+                        "underline": true
+                      }
+                    },
+                    {
+                      "text": ". Drinking the bottle of delicate elven wine will knock you out and put you at Isafdar (with your boat at Port Tyras), so dock at Port Tyras before drinking it.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "At your convenience, complete the Red Reef quest by chartering to the Great Conch and speaking with Floopa.",
+                      "formatting": {}
+                    },
+                    {
+                      "text": "\n",
+                      "formatting": {}
+                    }
+                  ]
+                }
+              ],
+              "metadata": {
+                "gp_stack": "35k gp",
+                "items_needed": "tbd",
+                "skills_quests_met": "yes",
+                "total_time": "tbd"
+              }
+            },
+            {
+              "content": [
+                {
+                  "text": "Boost to build an adamant helm on both your sloop and your skiff, then complete charting the Shrouded Ocean by charting to Deepfin Point and following the following route ",
+                  "formatting": {}
+                },
+                {
+                  "text": "Shrouded Ocean, part 2.png",
+                  "url": "https://drive.google.com/file/d/18KCtyaTWPL_l-Z_zBpDAafxBMAB_XMT1/view?usp=sharing",
+                  "isLink": true,
+                  "formatting": {
+                    "underline": true
+                  }
+                },
+                {
+                  "text": ".\n",
+                  "formatting": {}
+                }
+              ],
+              "nestedContent": [],
+              "metadata": {
+                "gp_stack": "35k gp",
+                "items_needed": "tbd",
+                "skills_quests_met": "yes",
+                "total_time": "tbd"
+              }
+            },
+            {
+              "content": [
+                {
+                  "text": "Go to Guardians of the Rift, participate in the minigame with the multiskilling method until you are completely out of uncut gems.\n",
+                  "formatting": {}
+                }
+              ],
+              "nestedContent": [
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "Guardians of the Rift - multiskilling",
+                      "url": "https://youtu.be/vAKese2xurs?list=PL1YmaQEbqW1jX9evljFu_CaJ-w-fueXUs",
+                      "isLink": true,
+                      "formatting": {
+                        "underline": true
+                      }
+                    },
+                    {
+                      "text": " - this video shows a simple example of multiskill Guardians of the Rift - you still make combination runes, but focus on skilling rather than participating throughout most of the game (in fact, you only enter the west essence mine when it opens and ignore all other opportunities to collect essence). ",
+                      "formatting": {}
+                    },
+                    {
+                      "text": "The best way",
+                      "formatting": {
+                        "bold": true
+                      }
+                    },
+                    {
+                      "text": " to multiskill is by carrying a gem bag full with uncut gems (60 sapphires, emeralds, rubies and diamonds) into the minigame, taking them out of the gem sack, cutting them and depositing them at the Deposit Pool (which acts as a regular deposit box!) one inventory at a time. The point and xp rate will be lower than active GotR, but the crafting xp makes it more efficient.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "An important strategy to increase your points per game (and per hour) at guardians of the rift is ‘empty cell running’. When out of essence, grab a cell from the table and enter an altar (higher tier is better) to charge the cell. Then deposit it for points, ideally on a golem but on a barrier is also fine. You can combine this with multiskilling for efficiency.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "Make an amulet of glory when you have the crafting level (75+5) to make one.\n",
+                      "formatting": {}
+                    }
+                  ]
+                }
+              ],
+              "metadata": {
+                "gp_stack": "35k gp",
+                "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "tbd"
               }
@@ -23286,19 +24733,10 @@
                       "formatting": {}
                     }
                   ]
-                },
-                {
-                  "level": 1,
-                  "content": [
-                    {
-                      "text": "After completing the full outfit and the colossal pouch, consider going for full bloodbark to help with future slayer. It is the most convenient to obtain +1% magic damage gear.\n",
-                      "formatting": {}
-                    }
-                  ]
                 }
               ],
               "metadata": {
-                "gp_stack": "44m",
+                "gp_stack": "44m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "tbd"
@@ -23317,7 +24755,7 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "47m",
+                "gp_stack": "47m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "tbd"
@@ -23378,7 +24816,7 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "49m",
+                "gp_stack": "49m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "tbd"
@@ -23387,7 +24825,7 @@
             {
               "content": [
                 {
-                  "text": "Use the money from CG to train smithing to level 86 with UIM gold. You’ll need to buy around 42.3k gold ores to get 86 Smithing for all diaries. Convert your cut diamonds and rubies into bracelets (optionally also enchant them, this is technically only worth it if you find a way to ‘0time’ it though) and charge enough unpowered orbs to match your battlestaves, then alch those/cash those in (e.g. at artefacts). Optional: also include ruby bracelets.",
+                  "text": "Use the money from CG to train smithing to level 86 with UIM gold. You’ll need to buy around 42.3k gold ores to get 86 Smithing for all diaries. Smelt at least 15 runite bars. Convert your cut diamonds and rubies into bracelets (optionally also enchant them, this is technically only worth it if you find a way to ‘0time’ it though) and charge enough unpowered orbs to match your battlestaves, then alch those/cash those in (e.g. at artefacts). Optional: also include ruby bracelets.",
                   "formatting": {}
                 },
                 {
@@ -23402,7 +24840,7 @@
                   "level": 1,
                   "content": [
                     {
-                      "text": "Optional: you can also train to ‘just’ level 83, so you can +5 for the Lumbridge Elite diary. This takes approximately 29.9k gold ores.\n",
+                      "text": "Optional: you can also train to ‘just’ level 83, so you can +5 for the Lumbridge Elite diary. This takes approximately 29.9k gold ores, but also means you can’t complete sailing.\n",
                       "formatting": {}
                     }
                   ]
@@ -23411,7 +24849,7 @@
                   "level": 1,
                   "content": [
                     {
-                      "text": "Optional: complete the Ardougne Elite Diary ‘make a rune crossbow from scratch’ step. If you have the rest of the stats complete the Ardougne Elite diary, this requires doing NMZ for imbuing a salve amulet.\n",
+                      "text": "Optional: complete the Ardougne Elite Diary ‘make a rune crossbow from scratch’ step. If you have the rest of the stats, complete the Ardougne Elite diary, this requires doing NMZ for imbuing a salve amulet.\n",
                       "formatting": {}
                     }
                   ]
@@ -23427,7 +24865,315 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "77m",
+                "gp_stack": "64m gp",
+                "items_needed": "tbd",
+                "skills_quests_met": "yes",
+                "total_time": "tbd"
+              }
+            },
+            {
+              "content": [
+                {
+                  "text": "Swap your kraken ink stout barrel on the sloop for perildance bitter. Collect port bounty tasks for the following activities. Note that bounty tasks are ",
+                  "formatting": {}
+                },
+                {
+                  "text": "not",
+                  "formatting": {
+                    "bold": true,
+                    "italic": true
+                  }
+                },
+                {
+                  "text": " bound to a specific location - you should teleport around to check all boards that can assign your desired target, regardless of where you want to do the task. Also most creatures drop two different bounty task items, so you can double dip on the xp by collecting both. See ",
+                  "formatting": {}
+                },
+                {
+                  "text": "Bounty tasks - OSRS Wiki",
+                  "formatting": {
+                    "underline": true,
+                    "color": {
+                      "r": 0.06666667,
+                      "g": 0.33333334,
+                      "b": 0.8
+                    },
+                    "url": "https://oldschool.runescape.wiki/w/Bounty_tasks",
+                    "isLink": true
+                  }
+                },
+                {
+                  "text": " for more info. Once you have completed the bounty tasks, or gotten enough xp for level 72 through other means, take your skiff to the Gwenith Glide and complete at least up to the shark rank, unlocking the Heart of ithell, and to 1,225,000 xp (level 75) - whichever comes later, you need both. While in the area, dock at Ynysdail to collect the small key, then dock at Lledrith to collect the dragon salvaging hook schematic. Boost to smith 3 runite bars into 45 rune nails (if you did not go to 86 smithing earlier this step is out of reach). Buy 4 magic stones at the Keldagrim stonemason. Build a crystal extractor on your sloop and on your skiff - make sure to put the skiff extractor next to the helm, but the sloop extractor on the port side next to your front facility hotspot. Boost to build an eternal brazier on your sloop and on your skiff. Boosting where necessary, chart the Northern ocean in full. This completes your charting, go to Chartin’ Charles McAtless to collect your XP bonuses and the Horizon’s lure - buy 50 of the drink and put it in a keg on both ships. If you did ship combat earlier you have the resources to build the gale catcher on your skiff, and the key ingredients (but not the level) to build a chum spreader and two cotton trawling nets for your sloop later.\n",
+                  "formatting": {}
+                }
+              ],
+              "nestedContent": [
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "Bounty tasks. Currently the main method of doing bounty tasks is just shooting the creatures with your bowfa, assigning your crew to deal a little bit of support damage with your cannons.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 2,
+                  "content": [
+                    {
+                      "text": "Here’s how to do bounty tasks:\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 3,
+                  "content": [
+                    {
+                      "text": "Travel (teleport/charter) around all places the tasks for one creature might be offered\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 3,
+                  "content": [
+                    {
+                      "text": "Travel (teleport/charter) to a dock closest to the creature and sail there\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 3,
+                  "content": [
+                    {
+                      "text": "Kill it until you complete one (or both, if it's close) of your two tasks\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 3,
+                  "content": [
+                    {
+                      "text": "Sail back, cash it in, go back to 1)\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 2,
+                  "content": [
+                    {
+                      "text": "These are the tasks to do:\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 3,
+                  "content": [
+                    {
+                      "text": "Stingray - 16 ray barbs for 2x cotton trawling net (best net for deepsea trawling). Kill them east off the coast of Aldarin, make sure to collect tasks for both fins and skins.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 3,
+                  "content": [
+                    {
+                      "text": "Albatross - 5 (or 10) swift albatross feathers for a gale catcher on your skiff (optional: and sloop). Kill them southeast of Etceteria, make sure to collect tasks for both beaks and feathers (which are different from swift feathers). Watch out, these require repair kits to stave off the damage.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 3,
+                  "content": [
+                    {
+                      "text": "Narwhal - 1 narwhal horn for a chum spreader (for deepsea trawling). Kill them southwest of Miscellania (dock at Etceteria). Make sure to collect tasks for both tusks and blubber.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 3,
+                  "content": [
+                    {
+                      "text": "The bottled storm (dropped by vampyre krakens) and some high tier dragon upgrades are not included in the guide. Likely these will be higher level content. If you want to go for these it is likely best to do so after finishing the charting.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "Charting: follow this route in the Northern Ocean. First follow the pink route with a raft, then follow the red route with your skiff, both starting from Rellekka",
+                      "formatting": {}
+                    },
+                    {
+                      "text": "Northern Ocean.png",
+                      "url": "https://drive.google.com/file/d/1WnYENWBNvxHZNplULc2ubvXVOdzLDHvG/view?usp=sharing",
+                      "isLink": true,
+                      "formatting": {
+                        "underline": true
+                      }
+                    },
+                    {
+                      "text": ". Drink the bottle of fishier bladderier stout shortly after getting it (complete the meteorologist first), you will be teleported to the troll arena with your ship docked at Rellekka again (just teleport out and resume the route). At Buccanneer’s Haven collect the eternal brazier schematic and the small key for the dragon cannon schematic, to be collected at your leisure.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 2,
+                  "content": [
+                    {
+                      "text": "You can get the bottle of exile’s welcome (crate in Lunar port) on a skiff by reversing and getting the player tile as close as possible to the crate. This bottle will teleport you to a random lunar teleport.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 2,
+                  "content": [
+                    {
+                      "text": "The bottle of kgp standard issue martini will teleport you to the Rellekka Hunter area.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 2,
+                  "content": [
+                    {
+                      "text": "The bottle of the winter sun will teleport you to the sand dune near Pollnivneach and your boat to the Ruins of Unkah.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 2,
+                  "content": [
+                    {
+                      "text": "It is recommended to finish the last three potions in this order:\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 3,
+                  "content": [
+                    {
+                      "text": "Drink the kgp standard issue martini, make your way back to Rellekka port\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 3,
+                  "content": [
+                    {
+                      "text": "Drink the winter sun, dueling ring to Al Kharid and make your way to Unkah.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 3,
+                  "content": [
+                    {
+                      "text": "Drink the exile’s welcome last.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "If, at this point, there are any charting tasks incomplete (and it’s not the meteorologists in Ardent, which you revisit at your own convenience) please inform us on discord.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "Train your woodcutting to level 80 (e.g. at teaks or sulliusceps), then travel (back) to Sunbleak Island, collect the dragon helm schematic and build the bank chest there if you want to (if you intend to afk woodcut, ironwood trees are a very good option - take lunar Plank Make to produce 4 planks on the island). Chop enough logs for 20 ironwood planks, taking into account plank vouchers if you have them. Optional but recommended: chop another 100 or so ironwood logs for Shades of Mort’ton, use this and your magic logs from While Guthix Sleeps to collect the bloodbark outfit for future slayer.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "The crystal extractor(s) will give you a significant amount of crystal shards while going for 99 sailing. They are always worth using during your sailing activities.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "With 78 slayer you gain access to Aquanites, and with 80 slayer you gain access to Nechryaels. Both have interesting sailing locations (Aquanites on Ynysdail drop a lot of herb seeds, the Nechryaels on the Charred Isle drop herb seeds and can be barraged).\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "At this point you are still missing two schematics: the rosewood & cotton sails and the dragon keel. Collect these at your own convenience when you have the levels.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "If you want the Sailor’s Amulet and haven’t gotten one yet, it is worth considering building rune salvaging hooks and salvaging for a bit. You can store the hooks in facility bottles after.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 1,
+                  "content": [
+                    {
+                      "text": "At a future point you may decide to go for 87 slayer, unlocking Grimstone. This island is notable for two things:\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 2,
+                  "content": [
+                    {
+                      "text": "The Frost dragons are a decent slayer task and have good rates of dropping dragon metal sheets.\n",
+                      "formatting": {}
+                    }
+                  ]
+                },
+                {
+                  "level": 2,
+                  "content": [
+                    {
+                      "text": "You can take the NPC ‘Isles’ with you from Port Robberts to Grimstone, after which he will unnote metal bars for you to use on the cannonball furnace. This lets you smelt up to 8.2k cballs per hour using the double cball mould. It is currently unclear whether this shifts the slayer meta, but it is the fastest and best way to make cannonballs if you want them anyway.\n",
+                      "formatting": {}
+                    }
+                  ]
+                }
+              ],
+              "metadata": {
+                "gp_stack": "60m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "tbd"
@@ -23535,7 +25281,7 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "77m",
+                "gp_stack": "60m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "tbd"
@@ -23573,7 +25319,7 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "77m",
+                "gp_stack": "60m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "tbd"
@@ -23705,7 +25451,7 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "77m",
+                "gp_stack": "60m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "tbd"
@@ -23720,7 +25466,7 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "77m",
+                "gp_stack": "60m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "tbd"
@@ -23747,7 +25493,7 @@
               ],
               "nestedContent": [],
               "metadata": {
-                "gp_stack": "77m",
+                "gp_stack": "58m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "tbd"
@@ -23798,7 +25544,7 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "58m",
+                "gp_stack": "25m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "tbd"
@@ -23871,14 +25617,14 @@
                   "level": 2,
                   "content": [
                     {
-                      "text": "Still open chests starting at level 51 room.\n",
+                      "text": "Still open sarcophagi starting at the level 51 room.\n",
                       "formatting": {}
                     }
                   ]
                 }
               ],
               "metadata": {
-                "gp_stack": "58m",
+                "gp_stack": "25m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "tbd"
@@ -23979,7 +25725,7 @@
                 }
               ],
               "metadata": {
-                "gp_stack": "39m",
+                "gp_stack": "6m gp",
                 "items_needed": "tbd",
                 "skills_quests_met": "yes",
                 "total_time": "1200 hours (rough estimate)"
@@ -24025,7 +25771,7 @@
         {
           "content": [
             {
-              "text": "20250309SlayerGuide",
+              "text": "20260525SlayerGuide",
               "url": "https://docs.google.com/document/d/1kBMW2uRI8b4NBcYn9PmsedTnZ3yW7fuGwdzsRQSCNkk/edit?usp=sharing",
               "isLink": true,
               "formatting": {
@@ -24623,7 +26369,7 @@
               }
             },
             {
-              "text": "4",
+              "text": "8",
               "formatting": {
                 "color": {
                   "r": 0,
@@ -24701,7 +26447,7 @@
               }
             },
             {
-              "text": "94",
+              "text": "97",
               "formatting": {
                 "color": {
                   "r": 0,
@@ -24767,7 +26513,29 @@
         {
           "content": [
             {
-              "text": "Hunter: 94\n",
+              "text": "Hunter: 9",
+              "formatting": {
+                "color": {
+                  "r": 0,
+                  "g": 0.6627451,
+                  "b": 0.2
+                },
+                "fontSize": 12,
+                "fontFamily": "Liberation Serif"
+              }
+            },
+            {
+              "text": "5",
+              "formatting": {
+                "color": {
+                  "r": 0,
+                  "g": 0.6627451,
+                  "b": 0.2
+                }
+              }
+            },
+            {
+              "text": "\n",
               "formatting": {
                 "color": {
                   "r": 0,
@@ -24796,7 +26564,7 @@
               }
             },
             {
-              "text": "98",
+              "text": "97",
               "formatting": {
                 "color": {
                   "r": 0,
@@ -24913,7 +26681,7 @@
         {
           "content": [
             {
-              "text": "Woodcutting: 7",
+              "text": "Woodcutting: ",
               "formatting": {
                 "color": {
                   "r": 0,
@@ -24925,7 +26693,7 @@
               }
             },
             {
-              "text": "3",
+              "text": "80",
               "formatting": {
                 "color": {
                   "r": 0,
@@ -24964,7 +26732,7 @@
               }
             },
             {
-              "text": "6",
+              "text": "6\n",
               "formatting": {
                 "color": {
                   "r": 0,
@@ -24972,17 +26740,20 @@
                   "b": 0.2
                 }
               }
-            },
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
             {
-              "text": "\n",
+              "text": "Sailing: 78\n",
               "formatting": {
                 "color": {
                   "r": 0,
-                  "g": 0,
-                  "b": 0
-                },
-                "fontSize": 12,
-                "fontFamily": "Liberation Serif"
+                  "g": 0.6627451,
+                  "b": 0.2
+                }
               }
             }
           ],
@@ -25003,7 +26774,7 @@
               }
             },
             {
-              "text": "2023\n",
+              "text": "2115\n",
               "formatting": {
                 "color": {
                   "r": 0,
@@ -25078,8 +26849,8 @@
               "formatting": {}
             },
             {
-              "text": "20251019Chapter1",
-              "url": "https://docs.google.com/document/d/1gCez5XG5FA1kmmBYydur3RaI_cr-dYNJlnigRrByEX8/edit?usp=sharing",
+              "text": "20260525Chapter1",
+              "url": "https://docs.google.com/document/d/1gCez5XG5FA1kmmBYydur3RaI_cr-dYNJlnigRrByEX8/edit",
               "isLink": true,
               "formatting": {
                 "underline": true
@@ -25087,7 +26858,9 @@
             },
             {
               "text": "\n",
-              "formatting": {}
+              "formatting": {
+                "bold": true
+              }
             }
           ],
           "type": "chapter_footnote"
@@ -25099,8 +26872,8 @@
               "formatting": {}
             },
             {
-              "text": "20251019Chapter2",
-              "url": "https://docs.google.com/document/d/1YQiZ6curEYPpgm3DtjZcWHPoEEkGpYdXZ-I0gCM5p10/edit?usp=sharing",
+              "text": "20260525Chapter2",
+              "url": "https://docs.google.com/document/d/1YQiZ6curEYPpgm3DtjZcWHPoEEkGpYdXZ-I0gCM5p10/edit",
               "isLink": true,
               "formatting": {
                 "underline": true
@@ -25120,7 +26893,7 @@
               "formatting": {}
             },
             {
-              "text": "20251019Chapter3",
+              "text": "20260525Chapter3",
               "url": "https://docs.google.com/document/d/1O1VeAkwS6VAzGVy0GT205GqiNaOAbw17H5uyuMwz39o/edit?usp=sharing",
               "isLink": true,
               "formatting": {
@@ -25141,8 +26914,8 @@
               "formatting": {}
             },
             {
-              "text": "20251019DetailedStepsGuide",
-              "url": "https://docs.google.com/spreadsheets/d/1XZ-3Kja7_QS4Rxj4mJXeATXHBP03lrdUSt46gO3pWHk/edit?usp=sharing",
+              "text": "20260525DetailedStepsGuide",
+              "url": "https://docs.google.com/spreadsheets/d/1XZ-3Kja7_QS4Rxj4mJXeATXHBP03lrdUSt46gO3pWHk/edit#gid=1506136399",
               "isLink": true,
               "formatting": {
                 "underline": true
@@ -25172,6 +26945,136 @@
                 },
                 "url": "https://drive.google.com/drive/folders/1mqirlAU0Pk5OGI5V8NN9BhHKIeGwG1Ea",
                 "isLink": true
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
+                "fontFamily": "Arial"
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "Tool for comparing Landlubber to current: ",
+              "formatting": {
+                "fontFamily": "Arial"
+              }
+            },
+            {
+              "text": "https://pobblesbe.github.io/bruhsailer-transition-tool/",
+              "formatting": {
+                "underline": true,
+                "color": {
+                  "r": 0.06666667,
+                  "g": 0.33333334,
+                  "b": 0.8
+                },
+                "fontFamily": "Arial",
+                "url": "https://pobblesbe.github.io/bruhsailer-transition-tool/",
+                "isLink": true
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {}
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "\n",
+              "formatting": {}
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "Landlubber version (pre sailing):\n",
+              "formatting": {
+                "italic": true,
+                "fontFamily": "Arial"
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20251019Chapter1 - Landlubber",
+              "url": "https://docs.google.com/document/d/1xZ03yH6BFzXVS5Q17ghYB6oiITD6xgSDgHy_Ar5PakU/edit?usp=drive_link",
+              "isLink": true,
+              "formatting": {
+                "underline": true,
+                "fontFamily": "Arial"
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
+                "fontFamily": "Arial"
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20251019Chapter2 - Landlubber",
+              "url": "https://docs.google.com/document/d/1ppJIpSY88DJMIcn0BBUBODe7wOrQFrKmjeNv0OvKVMs/edit?usp=sharing",
+              "isLink": true,
+              "formatting": {
+                "underline": true,
+                "fontFamily": "Arial"
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
+                "fontFamily": "Arial"
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20251019Chapter3 - Landlubber",
+              "url": "https://docs.google.com/document/d/1yPlKxtX96f4eYsXaga57Hl4EW7M8WMscVKaSfDoGGaA/edit?usp=sharing",
+              "isLink": true,
+              "formatting": {
+                "underline": true,
+                "fontFamily": "Arial"
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
+                "fontFamily": "Arial"
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20251019DetailedStepsGuide - Landlubber",
+              "url": "https://docs.google.com/spreadsheets/d/1BspIE07aWfP0Z2o2y3L5Qi9P27ctinDA9igNOkIhK3o/edit?usp=sharing",
+              "isLink": true,
+              "formatting": {
+                "underline": true,
+                "fontFamily": "Arial"
               }
             },
             {
@@ -25440,8 +27343,126 @@
             {
               "text": "\n",
               "formatting": {
+                "italic": true,
+                "fontSize": 11,
+                "fontFamily": "Arial"
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20260308BRUHsailerChangelog.txt",
+              "formatting": {
                 "underline": true,
-                "fontSize": 14
+                "color": {
+                  "r": 0.06666667,
+                  "g": 0.33333334,
+                  "b": 0.8
+                },
+                "fontFamily": "Arial",
+                "url": "https://drive.google.com/file/d/1sj648WdEj8dXS-kJm5xyKZFxa-APM5CX/view?usp=sharing",
+                "isLink": true
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
+                "underline": true,
+                "fontSize": 15
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20260310: Moved Zogre Flesh Eaters for early inoculation station, finished Shrouded Ocean",
+              "formatting": {
+                "italic": true
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
+                "fontFamily": "Arial"
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20260327BRUHsailerChangelog.txt",
+              "formatting": {
+                "underline": true,
+                "color": {
+                  "r": 0.06666667,
+                  "g": 0.33333334,
+                  "b": 0.8
+                },
+                "fontFamily": "Arial",
+                "url": "https://drive.google.com/file/d/16LdgtZVcg81vRr2-RZ-0J9tQW8kJG-sh/view?usp=sharing",
+                "isLink": true
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
+                "fontSize": 13
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20260410BRUHsailerChangelog.txt",
+              "formatting": {
+                "underline": true,
+                "color": {
+                  "r": 0.06666667,
+                  "g": 0.33333334,
+                  "b": 0.8
+                },
+                "url": "https://drive.google.com/file/d/1Vgsc6cbQkVZq0zK_1N8kiITWsTdirKJl/view?usp=sharing",
+                "isLink": true
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
+                "fontFamily": "Arial"
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "20260525BRUHsailerChangelog.txt",
+              "formatting": {
+                "underline": true,
+                "color": {
+                  "r": 0.06666667,
+                  "g": 0.33333334,
+                  "b": 0.8
+                },
+                "fontFamily": "Arial",
+                "url": "https://drive.google.com/file/d/1heQH8NuLiDIc7S9MwRoW-Y7uoRlgm-5-/view?usp=sharing",
+                "isLink": true
+              }
+            },
+            {
+              "text": "\n",
+              "formatting": {
+                "fontSize": 13
               }
             }
           ],
@@ -26546,7 +28567,7 @@
         {
           "content": [
             {
-              "text": "\t97+\t\tEfficient lance Slayer with aggressive skip list",
+              "text": "\t97+\t\t",
               "formatting": {
                 "color": {
                   "r": 0.7882353,
@@ -26554,6 +28575,16 @@
                   "b": 0.11764706
                 },
                 "fontSize": 12
+              }
+            },
+            {
+              "text": "Turael for imbued heart",
+              "formatting": {
+                "color": {
+                  "r": 0.7882353,
+                  "g": 0.12941177,
+                  "b": 0.11764706
+                }
               }
             },
             {
@@ -27104,7 +29135,7 @@
         {
           "content": [
             {
-              "text": "\t99+\t\thard farming contracts, fruit tree and hardwood runs, herb runs as needed",
+              "text": "\t99+\t\thard farming contracts, fruit tree and hardwood runs, herb runs as needed\n",
               "formatting": {
                 "color": {
                   "r": 0.7882353,
@@ -27112,6 +29143,54 @@
                   "b": 0.11764706
                 },
                 "fontSize": 12
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "Sailing\n",
+              "formatting": {
+                "color": {
+                  "r": 0.7882353,
+                  "g": 0.12941177,
+                  "b": 0.11764706
+                }
+              }
+            }
+          ],
+          "type": "chapter_footnote"
+        },
+        {
+          "content": [
+            {
+              "text": "78-99\t\tGwenith Glide is fastest, but several alternatives are attractive as well. Salvaging is low effort and quite high XP, and ship combat might prove promising in the future. Deepsea trawling gives lots of fish and so-so fishing xp but bad sailing xp (",
+              "formatting": {
+                "color": {
+                  "r": 0.7882353,
+                  "g": 0.12941177,
+                  "b": 0.11764706
+                }
+              }
+            },
+            {
+              "text": "marlin trawling | 60k fishing, 28k sailing",
+              "url": "https://www.youtube.com/watch?v=Hhl4kBCdZF0",
+              "isLink": true,
+              "formatting": {
+                "underline": true
+              }
+            },
+            {
+              "text": "), and courier tasks continue to be reasonable xp and good opportunities to multiskill",
+              "formatting": {
+                "color": {
+                  "r": 0.7882353,
+                  "g": 0.12941177,
+                  "b": 0.11764706
+                }
               }
             },
             {

--- a/scripts/copy-data.mjs
+++ b/scripts/copy-data.mjs
@@ -1,0 +1,35 @@
+// Sync guide data into public/ so the Vite build serves the latest content.
+//
+// `data/` is the single source of truth (the update-site workflow writes the
+// freshest guide JSON there). Vite only serves files under `public/`, so we
+// copy the data in before every build. This keeps `public/data/` from drifting
+// out of date relative to `data/` (which is exactly what stranded the deployed
+// site on an old "Last updated" date).
+
+import { mkdirSync, copyFileSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const srcDir = join(root, 'data');
+const destDir = join(root, 'public', 'data');
+
+const files = ['guide_data.json', 'guide_data_landlubber.json'];
+
+mkdirSync(destDir, { recursive: true });
+
+let copied = 0;
+for (const file of files) {
+  const src = join(srcDir, file);
+  if (!existsSync(src)) {
+    console.warn(`[copy-data] skip: data/${file} not found`);
+    continue;
+  }
+  copyFileSync(src, join(destDir, file));
+  copied++;
+  console.log(`[copy-data] data/${file} -> public/data/${file}`);
+}
+
+if (copied === 0) {
+  console.warn('[copy-data] no data files copied — is the data/ directory populated?');
+}


### PR DESCRIPTION
The Vite build serves public/data/, but the data-update workflow only refreshes data/. After the React rewrite merged, public/data/ was frozen on an old snapshot (2025-10-19) while data/ had advanced to 2026-05-25, so the deployed site showed a stale "Last updated" date.

Add scripts/copy-data.mjs and run it as a prebuild (and before dev) step so data/ is the single source of truth and public/data/ is regenerated on every build — the two can no longer drift. Also refreshes the tracked public/data/guide_data.json to the current 2026-05-25 content.