### PR TITLE
fix: restore existing users' progress from the old site

### DIFF
--- a/src/__tests__/components/Step.test.tsx
+++ b/src/__tests__/components/Step.test.tsx
@@ -41,6 +41,15 @@ describe('Step', () => {
     expect(checkbox).toBeChecked();
   });
 
+  it('migrates legacy `check-` prefixed progress from the old site', () => {
+    // Pre-React site keyed progress by the checkbox id (`check-1-1`).
+    localStorage.setItem('guideProgress:test', JSON.stringify({ 'check-1-1': true }));
+    renderWithGuide(<Step step={makeStep('Done step')} stepId="1-1" stepNumber={1} />);
+    expect(screen.getByRole('checkbox')).toBeChecked();
+    // Storage should be rewritten to the new, prefix-free format.
+    expect(JSON.parse(localStorage.getItem('guideProgress:test') || '{}')).toEqual({ '1-1': true });
+  });
+
   it('adds "completed" class after clicking the checkbox', async () => {
     const user = userEvent.setup();
     const { container } = renderWithGuide(

--- a/src/context/GuideContext.tsx
+++ b/src/context/GuideContext.tsx
@@ -38,6 +38,25 @@ function loadFromStorage<T>(key: string, fallback: T): T {
   }
 }
 
+// The original (pre-React) site stored progress keyed by the checkbox id,
+// e.g. `check-1-2`, while this version keys by the bare step id `1-2`. Both use
+// the same storage key (`guideProgress:<namespace>`) and the same step
+// numbering, so existing users already have their progress — it's just under
+// the old `check-` prefix. Strip the prefix on load so their checkboxes light
+// up again. Newer (already-bare) keys win if both happen to be present.
+function loadProgress(key: string): Record<string, boolean> {
+  const raw = loadFromStorage<Record<string, boolean>>(key, {});
+  const legacy = Object.keys(raw).filter((k) => k.startsWith('check-'));
+  if (legacy.length === 0) return raw;
+
+  const migrated: Record<string, boolean> = {};
+  for (const k of legacy) migrated[k.slice('check-'.length)] = raw[k];
+  for (const [k, v] of Object.entries(raw)) {
+    if (!k.startsWith('check-')) migrated[k] = v;
+  }
+  return migrated;
+}
+
 // ─── Provider ────────────────────────────────────────────────────────────────
 
 interface GuideProviderProps {
@@ -48,7 +67,7 @@ interface GuideProviderProps {
 export function GuideProvider({ namespace, children }: GuideProviderProps) {
   const initialState: GuideState = {
     namespace,
-    progress: loadFromStorage(storageKey('guideProgress', namespace), {}),
+    progress: loadProgress(storageKey('guideProgress', namespace)),
     filter: loadFromStorage<{ filter: 'all' | 'completed' | 'incomplete' }>(
       storageKey('guideFilter', namespace),
       { filter: 'all' }


### PR DESCRIPTION
The pre-React site stored step progress keyed by the checkbox id (`check-1-2`), while this version keys by the bare step id (`1-2`). Both use the same storage key and the same step numbering, so returning users still had their data — it was just under the old `check-` prefix, which made every checkbox read as unchecked while the progress bar (which only counts truthy values) still looked correct.

Strip the `check-` prefix when loading progress so existing checkmarks come back; the migrated, prefix-free object is then persisted on mount.