### PR TITLE
feat: add manual run button for the data-update workflow

### DIFF
--- a/.github/workflows/update-site.yml
+++ b/.github/workflows/update-site.yml
@@ -3,6 +3,10 @@ name: Update Website
 on:
   repository_dispatch:
     types: [google-docs-update]
+  # Manual "Run workflow" button. Uses the DRIVE_FOLDER_ID secret for the
+  # folder, so the same pipeline can be run from the Actions tab without the
+  # Google-Docs button (recovery/testing) and without exposing the ID.
+  workflow_dispatch:
 
 jobs:
   build:
@@ -27,7 +31,7 @@ jobs:
         run: node .github/scripts/download-files.cjs
         env:
           GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
-          FOLDER_ID: ${{ github.event.client_payload.folder_id }}
+          FOLDER_ID: ${{ github.event.client_payload.folder_id || secrets.DRIVE_FOLDER_ID }}
 
       - name: Transform and merge JSON to final data.json
         run: node conversion-script.cjs


### PR DESCRIPTION
Add a workflow_dispatch trigger to the Update Website workflow so the data pipeline can be run from the Actions tab without the Google-Docs button (useful for recovery and testing). The Drive folder ID comes from a new DRIVE_FOLDER_ID repository secret, falling back from the repository_dispatch payload, so manual runs need no input and the folder ID is never committed to the public repo or printed in logs.