### PR TITLE
fix: restore all steps when the search box is cleared

### DIFF
--- a/src/__tests__/integration/guideFilter.test.tsx
+++ b/src/__tests__/integration/guideFilter.test.tsx
@@ -85,6 +85,37 @@ describe('GuideView filter integration', () => {
     });
   });
 
+  it('search hides non-matching steps, and clearing it restores them', async () => {
+    const user = userEvent.setup();
+    renderGuideView();
+
+    const searchInput = screen.getByPlaceholderText('Search steps...');
+    await user.type(searchInput, 'first');
+
+    // Only the step whose text contains "first" stays visible.
+    await waitFor(
+      () => {
+        expect(document.getElementById('step-1-1')).not.toHaveClass('hidden-by-search');
+        expect(document.getElementById('step-1-2')).toHaveClass('hidden-by-search');
+      },
+      { timeout: 2000 }
+    );
+
+    await user.clear(searchInput);
+
+    // Emptying the search must bring every step back — regression test for the
+    // filter getting stuck because non-matching steps kept an inline display:none.
+    await waitFor(
+      () => {
+        document.querySelectorAll('.step').forEach((step) => {
+          expect(step).not.toHaveClass('hidden-by-search');
+          expect((step as HTMLElement).style.display).not.toBe('none');
+        });
+      },
+      { timeout: 2000 }
+    );
+  });
+
   it('"Incomplete" filter: last completed step is kept visible', async () => {
     const user = userEvent.setup();
     // Only step 1-2 completed (last completed = 1-2)

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -19,6 +19,17 @@ beforeAll(() => {
 
   // jsdom does not implement scrollIntoView
   window.HTMLElement.prototype.scrollIntoView = vi.fn();
+
+  // jsdom does not implement innerText; the search uses it for matching, so
+  // fall back to textContent (good enough for the visible-text comparison).
+  if (!Object.getOwnPropertyDescriptor(window.HTMLElement.prototype, 'innerText')) {
+    Object.defineProperty(window.HTMLElement.prototype, 'innerText', {
+      configurable: true,
+      get(this: HTMLElement) {
+        return this.textContent ?? '';
+      },
+    });
+  }
 });
 
 afterEach(() => {

--- a/src/components/guide/GuideView.tsx
+++ b/src/components/guide/GuideView.tsx
@@ -234,7 +234,6 @@ export default function GuideView({ guideData, chapters, allStepIds }: GuideView
       steps.forEach((stepEl) => {
         const matches = stepEl.innerText.toLowerCase().includes(term.toLowerCase());
         stepEl.classList.toggle('hidden-by-search', !matches);
-        stepEl.style.display = matches ? '' : 'none';
 
         if (matches) {
           const desc = stepEl.querySelector<HTMLElement>('.step-description');
@@ -246,7 +245,7 @@ export default function GuideView({ guideData, chapters, allStepIds }: GuideView
 
       root.querySelectorAll<HTMLElement>('.guide-section').forEach((section) => {
         const hasVisible = Array.from(section.querySelectorAll('.step')).some(
-          (s) => (s as HTMLElement).style.display !== 'none'
+          (s) => !(s as HTMLElement).classList.contains('hidden-by-search')
         );
         section.classList.toggle('hidden-by-search', !hasVisible);
         if (hasVisible) {


### PR DESCRIPTION
Searching set both a `hidden-by-search` class and an inline `display:none` on non-matching steps. Clearing the search only removed the class, so the inline style kept those steps hidden — leaving the guide stuck filtered with no way back short of reloading the page.

Drive visibility solely through the `hidden-by-search` class (CSS already applies display:none) and drop the redundant inline style. The section visibility check now reads the class instead of inline display.

Adds a regression test covering search-then-clear, plus an innerText polyfill in the test setup (jsdom does not implement it).